### PR TITLE
Merge hotfix/v4.6.2 into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Planned
 
-- Post-4.6.1 scope to be scheduled.
+- Post-4.6.2 scope to be scheduled.
+
+## [4.6.2] - 2026-03-08
+
+### Fixed
+
+- Console Server 404 on dotfile install paths (`.vscode/`, `.antigravity/`). Latent bug in Express `sendFile()` dotfile protection.
 
 ## [4.6.1] - 2026-03-08
 

--- a/FailSafe/extension/CHANGELOG.md
+++ b/FailSafe/extension/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Planned
 
-- Post-4.6.1 scope to be scheduled.
+- Post-4.6.2 scope to be scheduled.
+
+## [4.6.2] - 2026-03-08
+
+### Fixed
+
+- **Console Server inaccessible** — Express `sendFile()` silently returned 404 when the extension install path contained a dotfile directory (`.vscode/`, `.antigravity/`). Added `{ dotfiles: "allow" }` to all `sendFile` calls. This was a latent bug affecting all versions since the Console Server was introduced.
 
 ## [4.6.1] - 2026-03-08
 

--- a/FailSafe/extension/README.md
+++ b/FailSafe/extension/README.md
@@ -1,12 +1,18 @@
-[![Socket Badge](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.6.1?platform=universal)](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.6.1?platform=universal)
+[![Socket Badge](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.6.2?platform=universal)](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.6.2?platform=universal)
 
 # MythologIQ FailSafe for VS Code
 
 FailSafe is a local-first governance extension for AI-assisted development in VS Code and Cursor. It applies deterministic checks at the editor boundary, records decisions to a local ledger, and provides dedicated surfaces for audits, checkpoints, and agent governance.
 
-**Current Release**: v4.6.1 (2026-03-08)
+**Current Release**: v4.6.2 (2026-03-08)
 
 ![FailSafe Banner](https://raw.githubusercontent.com/MythologIQ/FailSafe/main/FailSafe/extension/FailSafe%20Banner.png)
+
+## What's New in v4.6.2
+
+### Fixes
+
+- **Console Server accessible again** — Fixed latent Express dotfile protection bug that caused 404 errors when extension was installed in dotfile directories (`.vscode/`, `.antigravity/`).
 
 ## What's New in v4.6.1
 

--- a/FailSafe/extension/docs/COMPONENT_HELP.md
+++ b/FailSafe/extension/docs/COMPONENT_HELP.md
@@ -1,6 +1,6 @@
 # FailSafe Component Help
 
-Audience: operators using the packaged VS Code extension (`v4.6.1`).
+Audience: operators using the packaged VS Code extension (`v4.6.2`).
 
 Scope: shipped UI surfaces, governance components, and Voice + Mindmap Status in the current release.
 

--- a/FailSafe/extension/docs/PROCESS_GUIDE.md
+++ b/FailSafe/extension/docs/PROCESS_GUIDE.md
@@ -1,6 +1,6 @@
 # FailSafe Process Guide
 
-Audience: operators who need fast, accurate workflows for the shipped `v4.6.1` UI and governance stack.
+Audience: operators who need fast, accurate workflows for the shipped `v4.6.2` UI and governance stack.
 
 ## First Run (Recommended Path)
 

--- a/FailSafe/extension/package.json
+++ b/FailSafe/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "FailSafe (feat. QoreLogic)",
   "description": "Complete AI governance for modern development. Genesis visualization + QoreLogic framework + Sentinel monitoring.",
   "icon": "media/icon.png",
-  "version": "4.6.1",
+  "version": "4.6.2",
   "publisher": "MythologIQ",
   "license": "MIT",
   "repository": {

--- a/FailSafe/extension/src/roadmap/ConsoleServer.ts
+++ b/FailSafe/extension/src/roadmap/ConsoleServer.ts
@@ -180,8 +180,9 @@ export class ConsoleServer {
     this.app.get("/", (req: Request, res: Response) => {
       const file = this.getUiEntryFile(req);
       const target = path.join(this.uiDir, file);
-      if (fs.existsSync(target)) { res.sendFile(target); return; }
-      res.sendFile(path.join(this.uiDir, "command-center.html"));
+      const sendOpts = { dotfiles: "allow" as const };
+      if (fs.existsSync(target)) { res.sendFile(target, sendOpts); return; }
+      res.sendFile(path.join(this.uiDir, "command-center.html"), sendOpts);
     });
 
     this.app.get("/health", (_req: Request, res: Response) => {
@@ -394,8 +395,9 @@ export class ConsoleServer {
       }
       const file = this.getUiEntryFile(req);
       const target = path.join(this.uiDir, file);
-      if (fs.existsSync(target)) { res.sendFile(target); return; }
-      res.sendFile(path.join(this.uiDir, "command-center.html"));
+      const sendOpts = { dotfiles: "allow" as const };
+      if (fs.existsSync(target)) { res.sendFile(target, sendOpts); return; }
+      res.sendFile(path.join(this.uiDir, "command-center.html"), sendOpts);
     });
   }
 

--- a/FailSafe/extension/src/test/governance/ObserveModeEvaluator.test.ts
+++ b/FailSafe/extension/src/test/governance/ObserveModeEvaluator.test.ts
@@ -18,8 +18,8 @@ suite("ObserveModeEvaluator", () => {
         axiom1: {
           enforce: () =>
             axiom1Status === "ALLOW"
-              ? { status: "ALLOW", reason: "ok", intentId: "test" }
-              : { status: "BLOCK", violation: "No intent", reason: "blocked" },
+              ? { status: "ALLOW" as const, reason: "ok", intentId: "test" }
+              : { status: "BLOCK" as const, violation: "No intent", reason: "blocked" },
         } as any,
         logger: { info: (...args: unknown[]) => logged.push(args) } as any,
         notifications: {

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _Local-first safety for AI coding assistants._
 [![GitHub Stars](https://img.shields.io/github/stars/MythologIQ/FailSafe?style=social)](https://github.com/MythologIQ/FailSafe/stargazers)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/status-stable-green)](https://github.com/MythologIQ/FailSafe)
-[![Socket Badge](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.6.1?platform=universal)](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.6.1?platform=universal)
+[![Socket Badge](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.6.2?platform=universal)](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.6.2?platform=universal)
 [![Node](https://img.shields.io/badge/node-18+-green.svg)](https://nodejs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue.svg)](https://www.typescriptlang.org)
 [![VS Code Extension](https://img.shields.io/badge/VS%20Code-Extension-007ACC?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=MythologIQ.mythologiq-failsafe)
@@ -19,7 +19,7 @@ _Local-first safety for AI coding assistants._
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Commands-8B5CF6)](https://github.com/MythologIQ/FailSafe/releases)
 [![Documentation](https://img.shields.io/badge/docs-FAILSAFE_SPECIFICATION-blue)](docs/FAILSAFE_SPECIFICATION.md)
 
-**Current Release**: v4.6.1 (2026-03-08)
+**Current Release**: v4.6.2 (2026-03-08)
 
 > **If this project helps you, please star it!** It helps others discover FailSafe.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -337,6 +337,7 @@ Minor / UX:
 | **v4.5.1**   | **Hotfix**                     | ✅ RELEASED    | Fix activation crash when ledger DB unavailable, fix validate.ps1 parameter mismatch                                 |
 | **v4.6.0**   | **Section 4 Razor**            | ✅ RELEASED    | Section 4 decomposition, voice brainstorm fixes, hook toggle UI, release gate enhancements                            |
 | **v4.6.1**   | **Hotfix**                     | ✅ RELEASED    | Missing sidebar SVG icon, release pipeline branch policy for tag CI, icon validation gate                             |
+| **v4.6.2**   | **Hotfix**                     | ✅ RELEASED    | Fix Console Server 404 on dotfile install paths (.vscode/, .antigravity/)                                             |
 
 ---
 


### PR DESCRIPTION
## Summary
- Fix Console Server 404 caused by Express dotfile protection on install paths containing `.vscode/` or `.antigravity/`
- Added `{ dotfiles: "allow" }` to all `sendFile()` calls in ConsoleServer.ts
- Latent bug affecting all versions — not a v4.6.1 regression

All 4 pipeline jobs passed. v4.6.2 published to both marketplaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)