### PR TITLE
fix: Update test mocks for ConsoleServer ledger

### DIFF
--- a/FailSafe/extension/src/test/consoleServer.test.ts
+++ b/FailSafe/extension/src/test/consoleServer.test.ts
@@ -37,9 +37,7 @@ describe("ConsoleServer workspace-root scoped reads", () => {
         getActivePlan: () => null,
       };
       const fakeQorelogicManager = {
-        getLedgerManager: () => {
-          throw new Error("test ledger unavailable");
-        },
+        getLedgerManager: () => null,
       };
       const fakeSentinelDaemon = {
         getStatus: () => ({ running: false, queueDepth: 0 }),

--- a/FailSafe/extension/src/test/securityHardening.test.ts
+++ b/FailSafe/extension/src/test/securityHardening.test.ts
@@ -23,9 +23,7 @@ suite("Security hardening coverage", () => {
         getActivePlan: () => null,
       };
       const fakeQorelogicManager = {
-        getLedgerManager: () => {
-          throw new Error("test ledger unavailable");
-        },
+        getLedgerManager: () => null,
       };
       const fakeSentinelDaemon = {
         getStatus: () => ({ running: false, queueDepth: 0 }),


### PR DESCRIPTION
## Summary

- Fix test mocks to return `null` instead of throwing for `getLedgerManager()`
- ConsoleServer now calls `getLedgerManager()` during construction for marketplace routes
- Tests were throwing errors that prevented ConsoleServer instantiation

## Test plan

- [x] TypeScript compilation passes
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)