### PR TITLE
chore(release): bump version markers to v4.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to FailSafe will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.0] - 2026-03-13
+
+### Added
+
+- Agent Execution Timeline: step-by-step visualization of agent actions with governance decision overlay (B142).
+- Risk & Stability Indicators: real-time agent health status with observe-mode notification and fallback logic (B143).
+- Shadow Genome Debugging Panel: interactive browser for failure patterns with filtering and pattern details (B144-B145).
+- New commands: `FailSafe: Agent Health Status`, `FailSafe: Agent Execution Timeline`, `FailSafe: Shadow Genome Debugger`.
+
 ## [4.7.2] - 2026-03-11
 
 ### Fixed

--- a/FailSafe/extension/CHANGELOG.md
+++ b/FailSafe/extension/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to the MythologIQ FailSafe extension will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.8.0] - 2026-03-13
+
+### Added
+
+- Agent Execution Timeline: step-by-step visualization of agent actions with governance decision overlay (B142).
+- Risk & Stability Indicators: real-time agent health status with observe-mode notification and fallback logic (B143).
+- Shadow Genome Debugging Panel: interactive browser for failure patterns with filtering and pattern details (B144-B145).
+- New commands: `FailSafe: Agent Health Status`, `FailSafe: Agent Execution Timeline`, `FailSafe: Shadow Genome Debugger`.
+
 ## [4.7.2] - 2026-03-11
 
 ### Fixed
@@ -14,12 +23,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Performance
 
 - Concurrent Folder Manifold Calculation: Shifted folder processing from sequential to concurrent using `Promise.all`, showing improved execution time during workspace initialization.
-
-## [Unreleased]
-
-### Planned
-
-- Post-4.7.2 scope to be scheduled.
 
 ## [4.7.0] - 2026-03-10
 

--- a/FailSafe/extension/README.md
+++ b/FailSafe/extension/README.md
@@ -1,12 +1,23 @@
-[![Socket Badge](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.7.0?platform=universal)](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.7.0?platform=universal)
+[![Socket Badge](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.8.0?platform=universal)](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.8.0?platform=universal)
 
 # MythologIQ FailSafe for VS Code
 
 FailSafe is a local-first governance extension for AI-assisted development in VS Code and Cursor. It applies deterministic checks at the editor boundary, records decisions to a local ledger, and provides dedicated surfaces for audits, checkpoints, and agent governance.
 
-**Current Release**: v4.7.2 (2026-03-11)
+**Current Release**: v4.8.0 (2026-03-13)
 
 ![FailSafe Banner](https://raw.githubusercontent.com/MythologIQ/FailSafe/main/FailSafe/extension/FailSafe%20Banner.png)
+
+## What's New in v4.8.0
+
+Agent Debugging & Stability Monitoring Suite — dedicated panels for agent execution timeline, risk indicators, and shadow genome debugging.
+
+### Added
+
+- **Agent Execution Timeline** — Step-by-step visualization of agent actions with governance decision overlay (B142).
+- **Risk & Stability Indicators** — Real-time agent health status with observe-mode notification and fallback logic (B143).
+- **Shadow Genome Debugging Panel** — Interactive browser for failure patterns with filtering and pattern details (B144-B145).
+- New commands: `FailSafe: Agent Health Status`, `FailSafe: Agent Execution Timeline`, `FailSafe: Shadow Genome Debugger`.
 
 ## What's New in v4.7.2
 

--- a/FailSafe/extension/docs/COMPONENT_HELP.md
+++ b/FailSafe/extension/docs/COMPONENT_HELP.md
@@ -1,6 +1,6 @@
 # FailSafe Component Help
 
-Audience: operators using the packaged VS Code extension (`v4.7.0`).
+Audience: operators using the packaged VS Code extension (`v4.8.0`).
 
 Scope: shipped UI surfaces, governance components, and Voice + Mindmap Status in the current release.
 

--- a/FailSafe/extension/docs/PROCESS_GUIDE.md
+++ b/FailSafe/extension/docs/PROCESS_GUIDE.md
@@ -1,6 +1,6 @@
 # FailSafe Process Guide
 
-Audience: operators who need fast, accurate workflows for the shipped `v4.7.0` UI and governance stack.
+Audience: operators who need fast, accurate workflows for the shipped `v4.8.0` UI and governance stack.
 
 ## First Run (Recommended Path)
 

--- a/FailSafe/extension/package.json
+++ b/FailSafe/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "FailSafe (feat. QoreLogic)",
   "description": "Complete AI governance for modern development. Genesis visualization + QoreLogic framework + Sentinel monitoring.",
   "icon": "media/icon.png",
-  "version": "4.7.2",
+  "version": "4.8.0",
   "publisher": "MythologIQ",
   "license": "MIT",
   "repository": {

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _Local-first safety for AI coding assistants._
 [![GitHub Stars](https://img.shields.io/github/stars/MythologIQ/FailSafe?style=social)](https://github.com/MythologIQ/FailSafe/stargazers)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/status-stable-green)](https://github.com/MythologIQ/FailSafe)
-[![Socket Badge](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.7.2?platform=universal)](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.7.2?platform=universal)
+[![Socket Badge](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.8.0?platform=universal)](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.8.0?platform=universal)
 [![Node](https://img.shields.io/badge/node-18+-green.svg)](https://nodejs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue.svg)](https://www.typescriptlang.org)
 [![VS Code Extension](https://img.shields.io/badge/VS%20Code-Extension-007ACC?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=MythologIQ.mythologiq-failsafe)
@@ -19,7 +19,7 @@ _Local-first safety for AI coding assistants._
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Commands-8B5CF6)](https://github.com/MythologIQ/FailSafe/releases)
 [![Documentation](https://img.shields.io/badge/docs-FAILSAFE_SPECIFICATION-blue)](docs/FAILSAFE_SPECIFICATION.md)
 
-**Current Release**: v4.7.2 (2026-03-11)
+**Current Release**: v4.8.0 (2026-03-13)
 
 > **If this project helps you, please star it!** It helps others discover FailSafe.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -356,7 +356,7 @@ Minor / UX:
 | **v4.6.6**   | **Workspace Isolation**        | ✅ RELEASED    | Multi-workspace support, Repository Governance as a Service, compliance scoring in Monitor, S.H.I.E.L.D. phase tracker |
 | **v4.7.0**   | **Agent Marketplace**          | ✅ RELEASED    | Agent Marketplace with HITL security gates, Garak/Promptfoo scanning, Microsoft Agent Governance Toolkit Adapter      |
 | **v4.7.2**   | **GitHub Resilience**          | ✅ RELEASED    | GitHub API resilience, concurrent manifold calculation, DiffGuard analysis panel                                       |
-| **v4.8.0**   | **Agent Debugging Suite**      | ✅ SEALED      | Agent Execution Timeline, Risk & Stability Indicators, Shadow Genome Debugging Panel (B142-B145)                      |
+| **v4.8.0**   | **Agent Debugging Suite**      | ✅ RELEASED    | Agent Execution Timeline, Risk & Stability Indicators, Shadow Genome Debugging Panel (B142-B145)                      |
 
 ---
 


### PR DESCRIPTION
## Summary
- Version markers were not updated when `release/v4.8.0` was merged via PR #28
- Updates package.json, READMEs, CHANGELOGs, COMPONENT_HELP, PROCESS_GUIDE
- Updates BACKLOG status from SEALED to RELEASED

## Files Changed
- `FailSafe/extension/package.json` — `4.7.2` → `4.8.0`
- `README.md` — badge URL + current release line
- `FailSafe/extension/README.md` — badge, current release, added "What's New in v4.8.0"
- `CHANGELOG.md` — added `[4.8.0]` entry
- `FailSafe/extension/CHANGELOG.md` — added `[4.8.0]` entry, removed `[Unreleased]`
- `FailSafe/extension/docs/COMPONENT_HELP.md` — `v4.7.0` → `v4.8.0`
- `FailSafe/extension/docs/PROCESS_GUIDE.md` — `v4.7.0` → `v4.8.0`
- `docs/BACKLOG.md` — v4.8.0: SEALED → RELEASED

## Test plan
- [x] All 588 unit tests pass
- [x] All 8 UI tests pass
- [x] VSIX packages successfully at v4.8.0
- [x] Release gate validates version markers

🤖 Generated with [Claude Code](https://claude.com/claude-code)