### PR TITLE
chore: bump version to 4.9.7 for release

### DIFF
--- a/FailSafe/extension/CHANGELOG.md
+++ b/FailSafe/extension/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the MythologIQ FailSafe extension will be documented in t
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.7] - 2026-03-17
+
+### Added
+
+- Governance mode configuration: `observe`, `assist`, `enforce` modes in `FailSafeConfig` and `ConfigManager` (B181).
+- External agent detection: `handleFileEdit()` in `AgentRunRecorder` auto-starts implicit runs on rapid file edits (B182).
+- Shadow Genome analysis: `analyzeAllPatterns()` returns patterns regardless of remediation status, with `/api/v1/genome` show-all toggle (B183).
+- Timeline click-to-expand: click any timeline entry to reveal full payload JSON (B184).
+
+### Fixed
+
+- Ghost path V1: `getGenomeAllPatterns` now declared in `ApiRouteDeps` interface.
+- Ghost path V2: `getGenomeAllPatterns` delegate wired in `ConsoleServer.ts`.
+
 ## [4.9.6] - 2026-03-16
 
 ### Added

--- a/FailSafe/extension/README.md
+++ b/FailSafe/extension/README.md
@@ -4,15 +4,28 @@ Prevent runaway AI edits, hallucinated dependencies, and destructive refactors b
 
 FailSafe runs locally inside VS Code and Cursor. It monitors what AI agents do, applies deterministic policy checks at the editor boundary, and gives you full visibility into every decision — before code ships.
 
-**Current Release**: v4.9.6 (2026-03-16)
+**Current Release**: v4.9.7 (2026-03-17)
 
 ![FailSafe Banner](https://raw.githubusercontent.com/MythologIQ/FailSafe/main/FailSafe/extension/FailSafe%20Banner.png)
 
-## What's New in v4.9.6
+## What's New in v4.9.7
+
+Governance mode configuration, external agent detection, genome pattern analysis improvements, and timeline UX enhancements.
+
+### Added
+
+- Governance mode configuration: `observe`, `assist`, `enforce` modes in settings (B181)
+- External agent detection via rapid file edit capture (B182)
+- Shadow Genome show-all toggle for pattern analysis (B183)
+- Timeline click-to-expand for full payload inspection (B184)
+
+---
+
+## v4.9.6
 
 SRE panel powered by the `agent-failsafe` adapter — active policies, trust scores, OWASP ASI coverage, and SLI compliance indicator directly in VS Code.
 
-### Added
+###
 
 - SRE panel in the Monitor sidebar: view active governance policies, enforcement status, OWASP ASI coverage map, and SLI compliance indicator.
 - SRE toggle button — switch between Monitor and SRE views without reloading the sidebar.

--- a/FailSafe/extension/package.json
+++ b/FailSafe/extension/package.json
@@ -3,7 +3,7 @@
   "displayName": "FailSafe (feat. QoreLogic)",
   "description": "Complete AI governance for modern development. Genesis visualization + QoreLogic framework + Sentinel monitoring.",
   "icon": "media/icon.png",
-  "version": "4.9.6",
+  "version": "4.9.7",
   "publisher": "MythologIQ",
   "license": "MIT",
   "repository": {


### PR DESCRIPTION
## Summary
- Bump package.json version from 4.9.6 to 4.9.7
- Add CHANGELOG entry for v4.9.7 features (B181-B184)
- Update README release marker

## Context
Release pipeline failed with SemVer violation — tag version '4.9.7' != package.json version '4.9.6'. This PR aligns the release metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)