### PR TITLE
docs: align v4.9.7 release documentation markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,21 @@ All notable changes to FailSafe will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [4.9.7] - 2026-03-17
+
+### Added
+
+- Release integrity: wire dead console routes, fix 5-tab CSS consolidation, bundle tab-count guard (B170-B173).
+- Debug unification: two-phase `/ql-debug` combining root-cause identification with residual sweep (B174).
+- Phase tracker stability: cache last known governance state, tail-read META_LEDGER optimization, debounce increase (B175-B177).
+- Diagnostic fixes: governance mode config, external agent capture, genome visibility, timeline expansion (B181-B184).
+
+### Fixed
+
+- SreTemplate Razor: extract section builders and `thresholdColor()` helper (D28-D29).
+- Ghost path: `getGenomeAllPatterns` wired in ApiRouteDeps and ConsoleServer (D31-D32).
+- Playwright UI tests updated for 5-tab consolidated layout.
+
 ## [4.9.6] - 2026-03-16
 
 ### Added

--- a/FailSafe/extension/docs/COMPONENT_HELP.md
+++ b/FailSafe/extension/docs/COMPONENT_HELP.md
@@ -1,6 +1,6 @@
 # FailSafe Component Help
 
-Audience: operators using the packaged VS Code extension (`v4.9.6`).
+Audience: operators using the packaged VS Code extension (`v4.9.7`).
 
 Scope: shipped UI surfaces, governance components, and Voice + Mindmap Status in the current release.
 

--- a/FailSafe/extension/docs/PROCESS_GUIDE.md
+++ b/FailSafe/extension/docs/PROCESS_GUIDE.md
@@ -1,6 +1,6 @@
 # FailSafe Process Guide
 
-Audience: operators who need fast, accurate workflows for the shipped `v4.9.6` UI and governance stack.
+Audience: operators who need fast, accurate workflows for the shipped `v4.9.7` UI and governance stack.
 
 ## First Run (Recommended Path)
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ _Local-first safety for AI coding assistants._
 [![GitHub Stars](https://img.shields.io/github/stars/MythologIQ/FailSafe?style=social)](https://github.com/MythologIQ/FailSafe/stargazers)
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Status](https://img.shields.io/badge/status-stable-green)](https://github.com/MythologIQ/FailSafe)
-[![Socket Badge](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.9.6?platform=universal)](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.9.6?platform=universal)
+[![Socket Badge](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.9.7?platform=universal)](https://badge.socket.dev/openvsx/package/mythologiq.mythologiq-failsafe/4.9.7?platform=universal)
 [![Node](https://img.shields.io/badge/node-18+-green.svg)](https://nodejs.org)
 [![TypeScript](https://img.shields.io/badge/TypeScript-5-blue.svg)](https://www.typescriptlang.org)
 [![VS Code Extension](https://img.shields.io/badge/VS%20Code-Extension-007ACC?logo=visual-studio-code)](https://marketplace.visualstudio.com/items?itemName=MythologIQ.mythologiq-failsafe)
@@ -19,7 +19,7 @@ _Local-first safety for AI coding assistants._
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-Commands-8B5CF6)](https://github.com/MythologIQ/FailSafe/releases)
 [![Documentation](https://img.shields.io/badge/docs-FAILSAFE_SPECIFICATION-blue)](docs/FAILSAFE_SPECIFICATION.md)
 
-**Current Release**: v4.9.6
+**Current Release**: v4.9.7
 
 > **If this project helps you, please star it!** It helps others discover FailSafe.
 

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -379,7 +379,7 @@ Minor / UX:
 - [x] [B182] Phase 2: Agent run capture for external agents — file-based session detection, implicit run creation (v4.9.7 - Complete)
 - [x] [B183] Phase 3: Genome view data visibility — show all patterns with status filter toggle (v4.9.7 - Complete)
 - [x] [B184] Phase 4: Timeline entry expansion — click-to-expand detail sections (v4.9.7 - Complete)
-- [x] [B185] ~~Phase 5: Clickable blocked message navigation~~ — DEFERRED to v4.9.8 (D33 prerequisite) | v4.9.7
+- [x] ~~Phase 5: Clickable blocked message navigation~~ — DEFERRED to v4.9.8 as B185 (D33 prerequisite) | v4.9.7
 
 ### v4.9.8 Blocked Navigation + Razor (plan-v498-blocked-navigation.md)
 


### PR DESCRIPTION
## Summary
- Root CHANGELOG.md: add ## [4.9.7] section with release notes
- Root README.md: Current Release + Socket badge → 4.9.7
- COMPONENT_HELP.md + PROCESS_GUIDE.md: version markers → v4.9.7
- BACKLOG.md: fix duplicate B185 reference

Preflight: all 8 checks PASS. Required for publishing workflow to succeed.

## Test plan
- [x] `release-gate.cjs --preflight` passes all 8 checks
- [x] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)