### PR TITLE
fix: remove unimplemented B49/B50/B51 interdiction gates from skills

### DIFF
--- a/.claude/skills/ql-implement/SKILL.md
+++ b/.claude/skills/ql-implement/SKILL.md
@@ -1,0 +1,272 @@
+---
+name: ql-implement
+description: >
+  Implementation Pass
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+---
+name: ql-implement
+description: Specialist Implementation Pass that translates gated blueprint into reality using Section 4 Simplicity Razor and TDD-Light methodology. Use when: (1) Implementing after PASS verdict from /ql-audit, (2) Building features from approved architecture plans, or (3) Creating code under KISS constraints.
+---
+
+# /ql-implement - Implementation Pass
+
+<skill>
+  <trigger>/ql-implement</trigger>
+  <phase>IMPLEMENT</phase>
+  <persona>Specialist</persona>
+  <output>Source code in src/, tests in tests/</output>
+</skill>
+
+## Purpose
+
+Translate the gated blueprint into maintainable reality using strict Section 4 Simplicity Razor constraints and TDD-Light methodology.
+
+## Execution Protocol
+
+### Step 1: Identity Activation
+
+You are now operating as **The QoreLogic Specialist**.
+
+Your role is to build with mathematical precision, ensuring Reality matches Promise.
+
+### Step 2: Gate Verification
+
+```
+Read: .failsafe/governance/AUDIT_REPORT.md
+```
+
+**INTERDICTION**: If verdict is NOT "PASS":
+
+```
+ABORT
+Report: "Gate locked. Tribunal audit required. Run /ql-audit first."
+```
+
+**INTERDICTION**: If AUDIT_REPORT.md does not exist:
+
+```
+ABORT
+Report: "No audit record found. Run /ql-audit to unlock implementation."
+```
+
+### Step 3: Blueprint Alignment
+
+```
+Read: docs/ARCHITECTURE_PLAN.md
+Read: docs/CONCEPT.md
+```
+
+Extract:
+
+- File tree (what to create)
+- Interface contracts (how it should work)
+- Risk grade (level of caution required)
+
+### Step 4: Build Path Trace
+
+Before creating ANY file:
+
+```
+Read: [entry point - main.tsx, index.ts, package.json]
+```
+
+Verify the target file will be connected to the build path.
+
+**If orphan detected**:
+
+```
+STOP
+Report: "Target file would be orphaned (not in build path).
+Verify import chain or update blueprint."
+```
+
+### Step 5: TDD-Light
+
+**Before writing any core logic**, create a minimal failing test.
+Template: `.claude/commands/references/ql-implement-patterns.md`.
+
+**Constraint**: Define exactly ONE success condition that proves Reality matches Promise.
+
+<!-- B49/B50/B51 interdiction gates removed — referenced files not yet implemented.
+     Re-add when tools/reliability/ scripts are created. -->
+
+### Step 6: Precision Build
+
+Apply the Section 4 Razor to EVERY function and file.
+Checklist: `.claude/commands/references/ql-implement-patterns.md`.
+
+#### Code Patterns
+
+Reference code patterns:
+`.claude/commands/references/ql-implement-patterns.md`.
+
+### Step 7: Visual Silence (Frontend)
+
+For UI examples, see:
+`.claude/commands/references/ql-implement-patterns.md`.
+
+### Step 8: Post-Build Cleanup
+
+Final pass checklist:
+`.claude/commands/references/ql-implement-patterns.md`.
+
+### Step 9: Complexity Self-Check
+
+Before declaring completion:
+
+```
+For each file modified/created:
+  - Count function lines
+  - Count nesting levels
+  - Check for nested ternaries
+  - Verify naming conventions
+```
+
+If ANY violation found:
+
+```
+PAUSE
+Report: "Section 4 violation detected. Running self-refactor before completion."
+Apply: Automatic splitting/flattening
+```
+
+### Step 10: Handoff
+
+Template:
+`.claude/commands/references/ql-implement-patterns.md`.
+
+### Step 10.5: Mark Blockers Complete
+
+If implementation addressed any blockers in BACKLOG.md:
+
+```
+Read: docs/BACKLOG.md
+Edit: docs/BACKLOG.md
+```
+
+For each addressed blocker:
+- Change: `- [ ] [ID]` -> `- [x] [ID]`
+- Append: ` (v[version] - Complete)`
+
+Example:
+```markdown
+- [x] [D4] V1: Ghost UI - toggleGuide handler missing (v1.2.0 - Complete)
+```
+
+### Step 11: Update Ledger
+
+Edit: docs/META_LEDGER.md
+
+Add entry:
+
+```markdown
+---
+
+### Entry #[N]: IMPLEMENTATION
+
+**Timestamp**: [ISO 8601]
+**Phase**: IMPLEMENT
+**Author**: Specialist
+**Risk Grade**: [from blueprint]
+
+**Files Modified**:
+
+- [list of files]
+
+**Content Hash**:
+```
+
+SHA256(modified files content)
+= [hash]
+
+```
+
+**Previous Hash**: [from entry N-1]
+
+**Chain Hash**:
+```
+
+SHA256(content_hash + previous_hash)
+= [calculated]
+
+```
+
+**Decision**: Implementation complete. Section 4 Razor applied.
+```
+
+### Step 12.5: Implementation Staging
+
+**Verify Reality = Blueprint**:
+1. Read docs/ARCHITECTURE_PLAN.md file tree
+2. Glob src/** and tests/**
+3. Compare: every planned file exists
+4. Verify: no unplanned orphans in src/
+
+IF verification FAILS:
+```
+ABORT: "Implementation incomplete"
+REPORT: Missing/unexpected files
+DO NOT STAGE
+```
+
+IF verification PASSES:
+
+**Auto-Stage**:
+```bash
+git add src/**
+git add tests/**
+git add docs/META_LEDGER.md
+git add docs/BACKLOG.md
+```
+
+**CHANGELOG Check** (if user-facing changes):
+IF CHANGELOG.md not updated AND changes are user-facing:
+- WARN: "Consider updating CHANGELOG.md for user-facing changes"
+
+REPORT: "Implementation verified. X files staged. Ready for commit."
+
+## Constraints
+
+- **NEVER** implement without PASS verdict
+- **NEVER** exceed Section 4 limits - split/refactor instead
+- **NEVER** skip TDD-Light for logic functions
+- **NEVER** leave console.log in code
+- **NEVER** create files not in blueprint without Governor approval
+- **NEVER** add dependencies without proving necessity
+- **ALWAYS** verify build path before creating files
+- **ALWAYS** mark addressed blockers as complete in BACKLOG.md
+- **ALWAYS** handoff to Judge for substantiation
+- **ALWAYS** update ledger with implementation hash
+
+## Success Criteria
+
+Implementation succeeds when:
+
+- [ ] AUDIT_REPORT.md shows PASS verdict
+- [ ] All files from ARCHITECTURE_PLAN.md created
+- [ ] All files connected to build path (no orphans)
+- [ ] Section 4 Razor applied to all functions (<=40 lines)
+- [ ] Section 4 Razor applied to all files (<=250 lines)
+- [ ] Nesting depth <=3 levels for all code
+- [ ] No nested ternaries in any code
+- [ ] TDD-Light tests written for all logic functions
+- [ ] No console.log statements in production code
+- [ ] META_LEDGER.md updated with implementation hash
+- [ ] Handoff to Judge for substantiation
+
+## Integration with QoreLogic
+
+This skill implements:
+
+- **Precision Build**: Mathematical precision matching Reality to Promise
+- **Section 4 Razor**: Strict simplicity constraints on all code
+- **TDD-Light**: Test-driven development for logic functions
+- **Build Path Verification**: Ensures no orphan files created
+- **Hash Chain Continuation**: Updates META_LEDGER with cryptographic linkage
+
+---
+
+**Remember**: Reality must match Promise. If you find yourself exceeding Section 4 limits, stop and refactor. Split functions, flatten nesting, remove complexity. Never compromise on simplicity for speed.

--- a/.claude/skills/ql-substantiate/SKILL.md
+++ b/.claude/skills/ql-substantiate/SKILL.md
@@ -1,0 +1,301 @@
+---
+name: ql-substantiate
+description: >
+  Session Seal
+user-invocable: true
+allowed-tools: Read, Glob, Grep, Edit, Write, Bash
+---
+
+---
+name: ql-substantiate
+description: S.H.I.E.L.D. Substantiation and Session Seal that verifies implementation against blueprint and cryptographically seals the session. Use when: (1) Implementation is complete, (2) Ready to verify Reality matches Promise, (3) Need to seal session with Merkle hash, or (4) Preparing to hand off completed work.
+---
+
+# /ql-substantiate - Session Seal
+
+<skill>
+  <trigger>/ql-substantiate</trigger>
+  <phase>SUBSTANTIATE</phase>
+  <persona>Judge</persona>
+  <output>Updated META_LEDGER.md with final seal, SYSTEM_STATE.md snapshot</output>
+</skill>
+
+## Purpose
+
+The final phase of the S.H.I.E.L.D. lifecycle. Verify that implementation matches the encoded blueprint (Reality = Promise), then cryptographically seal the session.
+
+## Execution Protocol
+
+### Step 1: Identity Activation
+You are now operating as **The QoreLogic Judge** in substantiation mode.
+
+Your role is to prove, not to improve. Verify what was built matches what was promised.
+
+### Step 2: State Verification
+
+```
+Read: docs/META_LEDGER.md
+Read: docs/ARCHITECTURE_PLAN.md
+Read: .failsafe/governance/AUDIT_REPORT.md
+```
+
+**INTERDICTION**: If no PASS verdict exists:
+```
+ABORT
+Report: "Cannot substantiate without PASS verdict. Run /ql-audit first."
+```
+
+**INTERDICTION**: If no implementation exists:
+```
+ABORT
+Report: "No implementation found. Run /ql-implement first."
+```
+
+### Step 2.5: Version Validation (MANDATORY)
+
+**Verify version consistency** between plan and current state:
+
+```bash
+git tag --sort=-v:refname | head -1
+```
+
+```
+Read: Plan file (docs/Planning/plan-*.md or docs/ARCHITECTURE_PLAN.md)
+Extract: Target Version from plan header
+```
+
+**INTERDICTION**: If Target Version ≤ Current Tag:
+```
+ABORT
+Report: "Version mismatch: Target v[X.Y.Z] already shipped (current tag: v[A.B.C]).
+         Bump version in plan before substantiating."
+```
+
+**INTERDICTION**: If SYSTEM_STATE.md or META_LEDGER.md reference wrong version:
+```
+PAUSE
+Report: "Version drift detected in governance files.
+         Expected: v[Target]
+         Found: v[Wrong]
+         Fix version references before sealing."
+```
+
+**Log validation**:
+```
+"Version validated: Current tag v[A.B.C] → Target v[X.Y.Z] (change type: [hotfix|feature|breaking])"
+```
+
+### Step 3: Reality Audit
+
+Compare implementation against blueprint:
+
+```
+Read: All files in src/
+Compare: Against docs/ARCHITECTURE_PLAN.md file tree
+```
+
+Template: `.claude/commands/references/ql-substantiate-templates.md`.
+
+**Findings**:
+- **MISSING**: Planned but not created -> FAIL
+- **UNPLANNED**: Created but not in blueprint -> WARNING (document in ledger)
+- **EXISTS**: Matches -> PASS
+
+### Step 3.5: Blocker Verification
+
+```
+Read: docs/BACKLOG.md
+```
+
+Check for open Security Blockers:
+
+```
+IF any unchecked Security Blockers exist:
+  WARNING: "Open security blockers detected. Consider addressing before seal."
+  List: [unchecked S# items]
+```
+
+Check for open Development Blockers related to current implementation:
+
+```
+IF related Dev Blockers exist:
+  WARNING: "Implementation may have unresolved blockers."
+  List: [related D# items]
+```
+
+### Step 4: Functional Verification
+
+#### Test Audit
+```
+Glob: tests/**/*.test.{ts,tsx,js}
+Read: Test files
+```
+
+Template: `.claude/commands/references/ql-substantiate-templates.md`.
+
+#### Visual Silence Verification (if frontend)
+```
+Grep: "color:" in src/**/*.{css,tsx}
+Grep: "background:" in src/**/*.{css,tsx}
+```
+
+Check for violations:
+Template: `.claude/commands/references/ql-substantiate-templates.md`.
+
+#### Console.log Artifacts
+```
+Grep: "console.log" in src/**/*
+```
+
+Template: `.claude/commands/references/ql-substantiate-templates.md`.
+
+### Step 4.5: Skill File Integrity Check
+
+If any skill files (`.claude/commands/ql-*.md`) were modified during this session:
+
+1. List modified skill files from git diff
+2. For each modified skill:
+   - Verify it still has required sections: `<skill>` block, `## Execution Protocol`, `## Constraints`, `## Next Step`
+   - Verify the `## Next Step` section references valid successor skills
+   - Log in ledger: "Skill file [name] modified — structure verified"
+
+If any skill is missing required sections after modification:
+
+```
+PAUSE
+Report: "Skill [name] missing required section: [section]. Fix before sealing."
+```
+
+<!-- B49/B50 evidence checks and reliability-run validator removed — referenced files not yet implemented.
+     Re-add when tools/reliability/ scripts are created. -->
+
+### Step 5: Section 4 Razor Final Check
+
+Template: `.claude/commands/references/ql-substantiate-templates.md`.
+
+### Step 6: Sync System State
+
+Map the final physical tree:
+
+```
+Glob: src/**/*
+Glob: tests/**/*
+Glob: docs/**/*
+```
+
+Create/Update `docs/SYSTEM_STATE.md`:
+
+Template: `.claude/commands/references/ql-substantiate-templates.md`.
+
+### Step 7: Final Merkle Seal
+
+Calculate session seal:
+
+Reference implementation: `.claude/commands/scripts/calculate-session-seal.py`.
+
+Update `docs/META_LEDGER.md`:
+
+Template: `.claude/commands/references/ql-substantiate-templates.md`.
+
+### Step 8: Cleanup Staging
+
+Clear: .failsafe/governance/
+
+Preserve only the final AUDIT_REPORT.md (or archive it).
+
+### Step 9: Final Report
+
+Template: `.claude/commands/references/ql-substantiate-templates.md`.
+
+### Step 9.5: Final Commit & Push
+
+**Stage All Artifacts**:
+```bash
+git add docs/CONCEPT.md
+git add docs/ARCHITECTURE_PLAN.md
+git add docs/META_LEDGER.md
+git add docs/SYSTEM_STATE.md
+git add docs/BACKLOG.md
+git add src/
+```
+
+**Commit Session Seal**:
+```bash
+git commit -m "seal: [plan-slug] - Session substantiated
+
+Merkle seal: [chain-hash]
+Verdict: PASS
+Files: [file-count]"
+```
+
+**Push to Remote**:
+```bash
+git push origin [current-branch]
+```
+
+REPORT: "Session committed and pushed to [current-branch]"
+
+### Step 9.6: Merge Options
+
+PROMPT user:
+
+```
+Session sealed. Ready to complete workflow.
+
+Options:
+1. Merge to main (if on feature branch)
+   git checkout main && git merge --no-ff [branch] -m "Merge [branch]: [summary]"
+
+2. Create PR (if remote available)
+   gh pr create --title "[summary]" --body "[from META_LEDGER decision]"
+
+3. Skip (stay on branch)
+
+Select option [1/2/3]:
+```
+
+IF option 1 (Merge):
+```bash
+git checkout main
+git merge --no-ff [branch] -m "Merge [branch]: [summary]"
+```
+
+IF option 2 (Create PR):
+```bash
+gh pr create --title "[summary]" --body "[from META_LEDGER decision]"
+```
+
+**Tag Prompt** (if version changed in SYSTEM_STATE.md):
+```
+Version changed: [old] -> [new]
+Create tag v[new_version]?
+
+Options:
+1. Yes - git tag -a v[X.Y.Z] -m "Release [X.Y.Z]"
+2. No - skip tagging
+```
+
+IF yes:
+```bash
+git tag -a v[X.Y.Z] -m "Release [X.Y.Z]: [summary]"
+```
+
+REPORT: "Session sealed. [Action taken: merged/PR created/branch only]"
+
+## Failure Scenarios
+
+### If Reality != Promise:
+
+Template: `.claude/commands/references/ql-substantiate-templates.md`.
+
+## Constraints
+
+- **NEVER** seal a session with Reality != Promise
+- **NEVER** skip any verification step
+- **NEVER** seal with Section 4 violations present
+- **NEVER** seal with version mismatch (Target ≤ Current Tag)
+- **ALWAYS** validate version before sealing
+- **ALWAYS** update SYSTEM_STATE.md before sealing
+- **ALWAYS** calculate proper chain hash
+- **ALWAYS** document any unplanned files in ledger
+- **ALWAYS** verify chain integrity before sealing


### PR DESCRIPTION
## Summary
Publishing workflow validation fails on missing `tools/reliability/` files referenced by ql-implement and ql-substantiate skills. These are aspirational gates (B49, B50, B51) that were never implemented. Commented out with re-add note.

## Test plan
- [x] Removes all 6 validation violations
- [x] No code changes — skill documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)