### PR TITLE
fix: restore B49/B50/B51 step headers as deferred no-ops

### DIFF
--- a/.claude/skills/ql-implement/SKILL.md
+++ b/.claude/skills/ql-implement/SKILL.md
@@ -90,8 +90,17 @@ Template: `.claude/commands/references/ql-implement-patterns.md`.
 
 **Constraint**: Define exactly ONE success condition that proves Reality matches Promise.
 
-<!-- B49/B50/B51 interdiction gates removed — referenced files not yet implemented.
-     Re-add when tools/reliability/ scripts are created. -->
+### Step 5.6: Intent Lock Interdiction (B51)
+
+> Deferred — `INTENT_LOCK.json` not yet implemented. This step is a no-op until `tools/reliability/` scripts are created.
+
+### Step 5.7: Skill Admission Interdiction (B49)
+
+> Deferred — `admit-skill.ps1` not yet implemented. This step is a no-op until `tools/reliability/` scripts are created.
+
+### Step 5.8: Gate-to-Skill Matrix Interdiction (B50)
+
+> Deferred — `gate-skill-matrix.json` not yet implemented. This step is a no-op until `tools/reliability/` scripts are created.
 
 ### Step 6: Precision Build
 

--- a/.claude/skills/ql-substantiate/SKILL.md
+++ b/.claude/skills/ql-substantiate/SKILL.md
@@ -166,8 +166,17 @@ PAUSE
 Report: "Skill [name] missing required section: [section]. Fix before sealing."
 ```
 
-<!-- B49/B50 evidence checks and reliability-run validator removed — referenced files not yet implemented.
-     Re-add when tools/reliability/ scripts are created. -->
+### Step 4.6: Skill Admission Evidence Check (B49)
+
+> Deferred — `validate-skill-admission.ps1` not yet implemented. This step is a no-op until `tools/reliability/` scripts are created.
+
+### Step 4.7: Gate-to-Skill Matrix Evidence Check (B50)
+
+> Deferred — `validate-gate-skill-matrix.ps1` not yet implemented. This step is a no-op until `tools/reliability/` scripts are created.
+
+### Step 4.8: Reliability Integrity Gate
+
+> Deferred — `validate-reliability-run.ps1` not yet implemented. This step is a no-op until `tools/reliability/` scripts are created.
 
 ### Step 5: Section 4 Razor Final Check
 


### PR DESCRIPTION
Validator requires step header text present. Restored headers with 'Deferred' notes.