### PR TITLE
v5.1.0 test fixes: 28→0 failures, ready for retag

### DIFF
--- a/FailSafe/extension/src/qorelogic/AgentOverlayLoader.ts
+++ b/FailSafe/extension/src/qorelogic/AgentOverlayLoader.ts
@@ -47,7 +47,21 @@ const AgentOverlayEnvelopeSchema = z.object({
   agents: z.array(z.unknown()),
 });
 
-export function loadAgentOverlay(workspaceRoot: string): AgentSystemManifest[] {
+/** Logger surface so tests can capture warnings without mutating console (the
+ *  vscode-test extension host wraps console.warn and the wrapper survives
+ *  test-local `console.warn = stub` reassignment). */
+export interface AgentOverlayLogger {
+  warn(message: string): void;
+}
+
+const DEFAULT_LOGGER: AgentOverlayLogger = {
+  warn: (m) => { console.warn(m); },
+};
+
+export function loadAgentOverlay(
+  workspaceRoot: string,
+  logger: AgentOverlayLogger = DEFAULT_LOGGER,
+): AgentSystemManifest[] {
   const overlayPath = path.join(workspaceRoot, ".failsafe", "agents.json");
   if (!fs.existsSync(overlayPath)) return [];
   try {
@@ -55,20 +69,23 @@ export function loadAgentOverlay(workspaceRoot: string): AgentSystemManifest[] {
       JSON.parse(fs.readFileSync(overlayPath, "utf-8")),
     );
     if (!envelope.success) return [];
-    return parseOverlayAgents(envelope.data.agents);
+    return parseOverlayAgents(envelope.data.agents, logger);
   } catch {
     return [];
   }
 }
 
-function parseOverlayAgents(rawAgents: unknown[]): AgentSystemManifest[] {
+function parseOverlayAgents(
+  rawAgents: unknown[],
+  logger: AgentOverlayLogger,
+): AgentSystemManifest[] {
   const out: AgentSystemManifest[] = [];
   for (const raw of rawAgents) {
     const result = AgentOverlaySchema.safeParse(raw);
     if (result.success) {
       out.push(result.data);
     } else {
-      console.warn(
+      logger.warn(
         `[AgentOverlayLoader] skipping invalid agent overlay entry: ${result.error.message}`,
       );
     }

--- a/FailSafe/extension/src/roadmap/ui/modules/install-skills-card.js
+++ b/FailSafe/extension/src/roadmap/ui/modules/install-skills-card.js
@@ -141,7 +141,7 @@ function groupDestinationsByHost(destinations) {
   // Returns Array<{ host: string, paths: string[] }> sorted by host.
   const groups = new Map();
   for (const p of destinations || []) {
-    const m = String(p).match(/[/\\](\.[\w-]+)[/\\]/);
+    const m = String(p).match(/(?:^|[/\\])(\.[\w-]+)(?:[/\\]|$)/);
     const host = m ? m[1].replace(/^\./, '') : 'other';
     if (!groups.has(host)) groups.set(host, []);
     groups.get(host).push(p);

--- a/FailSafe/extension/src/roadmap/ui/modules/install-skills-modal.js
+++ b/FailSafe/extension/src/roadmap/ui/modules/install-skills-modal.js
@@ -52,7 +52,7 @@ function renderErrorBlock(state) {
 function groupModalDestinations(destinations) {
   const groups = new Map();
   for (const p of destinations || []) {
-    const m = String(p).match(/[/\\](\.[\w-]+)[/\\]/);
+    const m = String(p).match(/(?:^|[/\\])(\.[\w-]+)(?:[/\\]|$)/);
     const host = m ? m[1].replace(/^\./, '') : 'other';
     if (!groups.has(host)) groups.set(host, []);
     groups.get(host).push(p);

--- a/FailSafe/extension/src/roadmap/ui/modules/live-transcriber.js
+++ b/FailSafe/extension/src/roadmap/ui/modules/live-transcriber.js
@@ -1,7 +1,7 @@
 // FailSafe Command Center — Live Transcriber
 // Real-time interim transcription via Web Speech API during Whisper recording.
 
-import { SpeechRecognitionCtor } from './whisper-loader.js';
+import { getSpeechRecognitionCtor } from './whisper-loader.js';
 
 export class LiveTranscriber {
   constructor() {
@@ -10,9 +10,10 @@ export class LiveTranscriber {
   }
 
   start(language, onTranscript, onSilenceReset, getState) {
-    if (!SpeechRecognitionCtor || this._recognition) return;
+    const Ctor = getSpeechRecognitionCtor();
+    if (!Ctor || this._recognition) return;
     try {
-      this._recognition = new SpeechRecognitionCtor();
+      this._recognition = new Ctor();
       this._recognition.continuous = true;
       this._recognition.interimResults = true;
       this._recognition.lang = language;

--- a/FailSafe/extension/src/roadmap/ui/modules/wake-word-listener.js
+++ b/FailSafe/extension/src/roadmap/ui/modules/wake-word-listener.js
@@ -1,7 +1,7 @@
 // FailSafe Command Center — Wake Word Listener
 // Detects wake phrase via Web Speech API to trigger recording.
 
-import { SpeechRecognitionCtor } from './whisper-loader.js';
+import { getSpeechRecognitionCtor } from './whisper-loader.js';
 
 export class WakeWordListener {
   constructor(store) {
@@ -30,12 +30,13 @@ export class WakeWordListener {
   }
 
   start(onTriggered, onError, getState) {
-    if (!SpeechRecognitionCtor) {
+    const Ctor = getSpeechRecognitionCtor();
+    if (!Ctor) {
       onError?.('Voice activation unavailable in this environment');
       return false;
     }
     if (this._recognition) return true;
-    this._recognition = new SpeechRecognitionCtor();
+    this._recognition = new Ctor();
     this._recognition.continuous = true;
     this._recognition.interimResults = true;
     this._onError = onError;

--- a/FailSafe/extension/src/roadmap/ui/modules/whisper-loader.js
+++ b/FailSafe/extension/src/roadmap/ui/modules/whisper-loader.js
@@ -39,5 +39,10 @@ export async function checkMicAvailable() {
   }
 }
 
-export const SpeechRecognitionCtor =
-  globalThis.SpeechRecognition || globalThis.webkitSpeechRecognition || null;
+// Evaluated at call time, not module load time, so tests that assign
+// globalThis.SpeechRecognition after ES-module import hoisting still resolve
+// the fake. (Module-level const captured the value before assignments could
+// land — broke FX221 SttEngine tests.)
+export function getSpeechRecognitionCtor() {
+  return globalThis.SpeechRecognition || globalThis.webkitSpeechRecognition || null;
+}

--- a/FailSafe/extension/src/test/qorelogic/AgentOverlayLoader.test.ts
+++ b/FailSafe/extension/src/test/qorelogic/AgentOverlayLoader.test.ts
@@ -90,11 +90,8 @@ suite("AgentOverlayLoader Test Suite", () => {
 
   test("agent missing required fields is skipped with warning", () => {
     const root = makeWorkspace();
-    const originalWarn = console.warn;
     let warned = 0;
-    console.warn = () => {
-      warned += 1;
-    };
+    const logger = { warn: () => { warned += 1; } };
     try {
       writeOverlay(
         root,
@@ -105,12 +102,11 @@ suite("AgentOverlayLoader Test Suite", () => {
           ],
         }),
       );
-      const result = loadAgentOverlay(root);
+      const result = loadAgentOverlay(root, logger);
       assert.strictEqual(result.length, 1);
       assert.strictEqual(result[0].id, "ok");
       assert.ok(warned >= 1, "should warn on the skipped entry");
     } finally {
-      console.warn = originalWarn;
       cleanup(root);
     }
   });

--- a/FailSafe/extension/src/test/roadmap/install-skills-card.test.ts
+++ b/FailSafe/extension/src/test/roadmap/install-skills-card.test.ts
@@ -131,7 +131,9 @@ suite('install-skills-card (FX234 + FX237 + FX238 + FX240)', () => {
       lastReport: { ok: true, totalInstalled: 17, destinations: ['.claude/skills/'], failures: [] },
     });
     assert.match(html, /var\(--accent-teal/);
-    assert.match(html, /Installed 17 skill\(s\) at .claude\/skills\//);
+    // Renderer groups destinations by agent-host segment; '.claude/skills/' → host 'claude'.
+    assert.match(html, /Installed 17 skills across claude\./);
+    assert.match(html, /\.claude\/skills\//);
   });
 
   test('renderInstallSkillsCard — lastReport ok=false renders gold partial-failure message', () => {
@@ -141,7 +143,7 @@ suite('install-skills-card (FX234 + FX237 + FX238 + FX240)', () => {
       lastReport: { ok: false, totalInstalled: 5, destinations: [], failures: [{ host: 'codex', error: 'x' }] },
     });
     assert.match(html, /var\(--accent-gold/);
-    assert.match(html, /1 host\(s\) failed/);
+    assert.match(html, /Installed 5 skills; 1 host failed\./);
   });
 
   test('renderInstallSkillsCard — lastReport ignored while running=true', () => {
@@ -167,7 +169,10 @@ suite('install-skills-card (FX234 + FX237 + FX238 + FX240)', () => {
   test('FX234/FX237 bindInstallSkillsCard — Install button opens modal; confirm POSTs /api/actions/scaffold-skills', async () => {
     const f = installFetch(() => ({ ok: true, body: { ok: true, totalInstalled: 17 } }));
     try {
-      const html = renderInstallSkillsCard({ running: false, invocations: [], lastReport: null });
+      const html = renderInstallSkillsCard(
+        { running: false, invocations: [], lastReport: null },
+        { bootstrapState: { qorLogicInstall: { hosts: [{ host: 'claude', installed: false }] } } },
+      );
       mountHtml(domR.dom, html);
       const root = domR.dom.window.document.getElementById('root')!;
       let started = 0;
@@ -196,7 +201,10 @@ suite('install-skills-card (FX234 + FX237 + FX238 + FX240)', () => {
     // valid — that selector doesn't exist in the new modal markup.
     const f = installFetch(() => ({ ok: false, body: { ok: false, error: 'pip exit 1' } }));
     try {
-      const html = renderInstallSkillsCard({ running: false, invocations: [], lastReport: null });
+      const html = renderInstallSkillsCard(
+        { running: false, invocations: [], lastReport: null },
+        { bootstrapState: { qorLogicInstall: { hosts: [{ host: 'claude', installed: false }] } } },
+      );
       mountHtml(domR.dom, html);
       const root = domR.dom.window.document.getElementById('root')!;
       bindInstallSkillsCard(root, {});
@@ -218,7 +226,10 @@ suite('install-skills-card (FX234 + FX237 + FX238 + FX240)', () => {
     const original = (globalThis as { fetch?: unknown }).fetch;
     (globalThis as { fetch: unknown }).fetch = async () => { throw new Error('offline'); };
     try {
-      const html = renderInstallSkillsCard({ running: false, invocations: [], lastReport: null });
+      const html = renderInstallSkillsCard(
+        { running: false, invocations: [], lastReport: null },
+        { bootstrapState: { qorLogicInstall: { hosts: [{ host: 'claude', installed: false }] } } },
+      );
       mountHtml(domR.dom, html);
       const root = domR.dom.window.document.getElementById('root')!;
       let errorCaught: Error | null = null;

--- a/FailSafe/extension/src/test/roadmap/stt-engine-transcription.test.ts
+++ b/FailSafe/extension/src/test/roadmap/stt-engine-transcription.test.ts
@@ -31,10 +31,10 @@ class FakeRecognition {
   }
 }
 
-(globalThis as any).SpeechRecognition = FakeRecognition;
-(globalThis as any).webkitSpeechRecognition = FakeRecognition;
-
-// JS module import in TS test context.
+// JS module import in TS test context. whisper-loader's getSpeechRecognitionCtor()
+// now resolves at call time, so suiteSetup-time global install is sufficient —
+// no module-level assignment needed (which previously leaked into adjacent
+// suites' Node-env assumptions — broke FX228 WakeWordListener test).
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 import { SttEngine } from "../../../src/roadmap/ui/modules/stt-engine.js";
@@ -89,6 +89,18 @@ function installRecorderShim(engine: any) {
 }
 
 suite("SttEngine transcription lifecycle (FX221)", () => {
+  suiteSetup(() => {
+    (globalThis as { SpeechRecognition?: unknown }).SpeechRecognition = FakeRecognition;
+    (globalThis as { webkitSpeechRecognition?: unknown }).webkitSpeechRecognition = FakeRecognition;
+  });
+
+  suiteTeardown(() => {
+    // FX221 + FX228 isolation: clean the FakeRecognition stub so adjacent
+    // suites (WakeWordListener FX228) see the bare Node env they assume.
+    delete (globalThis as { SpeechRecognition?: unknown }).SpeechRecognition;
+    delete (globalThis as { webkitSpeechRecognition?: unknown }).webkitSpeechRecognition;
+  });
+
   setup(() => {
     recognitionInstances.length = 0;
   });

--- a/FailSafe/extension/src/test/roadmap/stt-silence-timer.test.ts
+++ b/FailSafe/extension/src/test/roadmap/stt-silence-timer.test.ts
@@ -1,8 +1,9 @@
 import * as assert from "assert";
 
-// SttEngine depends on browser globals — stub the minimum so the module loads.
-(globalThis as any).SpeechRecognition ??= class {};
-(globalThis as any).webkitSpeechRecognition ??= class {};
+// whisper-loader's getSpeechRecognitionCtor() resolves at call time, so
+// SttEngine + LiveTranscriber load cleanly under Node without browser globals.
+// (Removed the legacy `globalThis.SpeechRecognition ??= class {}` stub — it
+// leaked an addEventListener-less class into adjacent FX228 tests.)
 
 import { SttEngine } from "../../../src/roadmap/ui/modules/stt-engine.js";
 

--- a/FailSafe/extension/src/test/securityHardening.test.ts
+++ b/FailSafe/extension/src/test/securityHardening.test.ts
@@ -181,7 +181,9 @@ suite("Security hardening coverage", () => {
       (manifest.contributes?.commands || []).map((c) => c.command || ""),
     );
     assert.strictEqual(commands.has("failsafe.openRiskRegister"), true);
-    assert.strictEqual(commands.has("failsafe.addRisk"), true);
+    // failsafe.addRisk removed in v5.1.0 (plan-qor-model-sourced-risks).
+    // Risks now sourced via MCP tool + chat subcommand + auto-derivation.
+    assert.strictEqual(commands.has("failsafe.addRisk"), false);
 
     const sidebarViews = manifest.contributes?.views?.["failsafe-sidebar-container"] || [];
     const viewIds = new Set(sidebarViews.map((v) => v.id || ""));

--- a/FailSafe/extension/src/test/shared/gitignore.test.ts
+++ b/FailSafe/extension/src/test/shared/gitignore.test.ts
@@ -27,7 +27,11 @@ afterEach(function () {
   }
 });
 
-describe("ensureFailsafeGitignoreEntry", () => {
+describe("ensureFailsafeGitignoreEntry", function () {
+  // Windows mkdtempSync + writeFileSync can briefly exceed 2s under
+  // antivirus or concurrent prepush-hook filesystem load. Allow headroom.
+  this.timeout(10000);
+
   it("creates .gitignore with .failsafe/ when missing", () => {
     const workspace = makeTempWorkspace();
     const changed = ensureFailsafeGitignoreEntry(workspace);


### PR DESCRIPTION
## Summary
- Resolves 28 test failures blocking the v5.1.0 release pipeline
- Includes follow-on `gitignore.test.ts` timeout bump for Windows fs flake under prepush hook concurrency
- Compatible with qor-logic v0.55.1 (closes [Qor-logic#77](https://github.com/MythologIQ-Labs-LLC/Qor-logic/issues/77))

## Commits
- `6d2766b` fix(test): resolve all 27 remaining test failures (v5.1.0 unblock)
- `63fe334` fix(test): bump gitignore.test.ts suite timeout to 10s

## Test plan
- [x] `npm run test:all` locally — 2348 passing, 1 pending, 0 failing
- [x] Pre-push gate fully green (compile + tests + VSIX package + VSIX validate)
- [ ] After merge: delete remote v5.1.0 tag, retag at merge commit, push tag → release.yml fires
- [ ] Production environment approval gate at @Knapp-Kevin
- [ ] Dual marketplace publish (VS Code + Open VSX) lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)