### PR TITLE
v5.1.0 CI fixes: dist bundle, FeedbackManager init, mocha timeout

### DIFF
--- a/FailSafe/extension/package.json
+++ b/FailSafe/extension/package.json
@@ -391,7 +391,7 @@
     "bundle": "node ./scripts/bundle.cjs",
     "compile": "tsc -p ./ && node ./scripts/copy-ui-js.cjs",
     "watch": "tsc -watch -p ./",
-    "pretest": "npm run compile && npm run patch:better-sqlite3 && npm run rebuild:vscode",
+    "pretest": "npm run build:package && npm run patch:better-sqlite3 && npm run rebuild:vscode",
     "patch:better-sqlite3": "node ./scripts/patch-better-sqlite3.cjs",
     "rebuild:vscode": "node ./scripts/rebuild-vscode-electron.cjs",
     "test": "vscode-test --extensionDevelopmentPath . --extensionTestsPath ./out/test/suite/index .",

--- a/FailSafe/extension/src/genesis/FeedbackManager.ts
+++ b/FailSafe/extension/src/genesis/FeedbackManager.ts
@@ -53,18 +53,18 @@ export class FeedbackManager {
         this.context = context;
         // Feedback directory in workspace root under .failsafe/feedback
         const workspaceRoot = vscode.workspace.workspaceFolders?.[0]?.uri.fsPath;
-        this.feedbackDir = workspaceRoot 
+        this.feedbackDir = workspaceRoot
             ? path.join(workspaceRoot, '.failsafe', 'feedback')
             : path.join(context.globalStorageUri.fsPath, 'feedback');
-        
-        // Ensure feedback directory exists
-        this.ensureFeedbackDirectory();
-        
-        // Lazy load logger to avoid circular dependency
+
+        // Logger must be initialized before ensureFeedbackDirectory(), which
+        // calls this.logger.info on the cold-start mkdirSync path.
         this.logger = {
             info: (msg: string, data?: unknown) => console.log(`[FeedbackManager] ${msg}`, data || ''),
             error: (msg: string, error?: unknown) => console.error(`[FeedbackManager] ${msg}`, error || '')
         };
+
+        this.ensureFeedbackDirectory();
     }
 
     /**

--- a/FailSafe/extension/src/test/extension/skills-api-route.test.ts
+++ b/FailSafe/extension/src/test/extension/skills-api-route.test.ts
@@ -44,7 +44,11 @@ function makeDeps(workspaceRoot: string, dirname: string): ApiRouteDeps {
   } as ApiRouteDeps;
 }
 
-suite('registerSkillsApiRoute', () => {
+suite('registerSkillsApiRoute', function () {
+  // Tests use temp-dir + bundled SkillIngestor + Express harness — can exceed
+  // mocha's 2s default on Windows/CI under filesystem load.
+  this.timeout(15000);
+
   let harness: RouteHarness;
   let tmpRoot: string;
 

--- a/FailSafe/extension/src/test/suite/index.ts
+++ b/FailSafe/extension/src/test/suite/index.ts
@@ -6,8 +6,11 @@ export async function run(): Promise<void> {
   const mocha = new Mocha({
     ui: 'bdd',
     color: true,
-    timeout: 5000
+    timeout: 15000
   });
+  // Belt + suspenders: explicit setter overrides any nested suite that
+  // accidentally inherits mocha's 2000ms built-in default.
+  mocha.timeout(15000);
 
   const testsRoot = path.resolve(__dirname, '..');
   const testFiles = await glob('**/*.test.js', { cwd: testsRoot });


### PR DESCRIPTION
## Summary
- Three real CI failures, all surfaced after the prior round of test fixes pushed
- Resolves the 17-test extension-activation cascade plus 2 FeedbackManager + flaky-timeout cluster

## Root causes
1. **`pretest` didn't bundle** — extension `main` is `dist/extension/main.js`, only `vsce package` ran the bundle step. CI fresh-checkout had no `dist/` → activation failed → 17 command-dispatch tests cascaded to "command 'failsafe.X' not found"
2. **FeedbackManager constructor order** — `ensureFeedbackDirectory()` called before `this.logger` init; cold-start mkdir path crashed
3. **Mocha 2s default** — runner timeout: 5000 didn't propagate; bumped to 15s with explicit setter

## Verification
- Deleted local `dist/`, ran `npm test`: 2348 passing, 1 pending, 0 failing
- Pre-push gate fully green (compile + bundle + tests + VSIX validate)

## Test plan
- [x] Local clean-slate test run green
- [x] Pre-push gate green
- [ ] CI Build & Test passes after retag

🤖 Generated with [Claude Code](https://claude.com/claude-code)