### PR TITLE
v5.1.0: apply mocha timeout in .vscode-test.mjs (CLI ignores custom runner)

### DIFF
--- a/FailSafe/extension/.vscode-test.mjs
+++ b/FailSafe/extension/.vscode-test.mjs
@@ -8,5 +8,14 @@ const __dirname = path.dirname(__filename);
 export default defineConfig({
   files: 'out/test/**/*.test.js',
   extensionDevelopmentPath: __dirname,
-  workspaceFolder: path.join(__dirname, 'src', 'test', 'test-workspace')
+  workspaceFolder: path.join(__dirname, 'src', 'test', 'test-workspace'),
+  // @vscode/test-cli ignores --extensionTestsPath when this config exists, so
+  // the custom out/test/suite/index runner (which sets 15s) never runs. Set
+  // mocha defaults here too. 15s headroom covers Windows fs flake under
+  // prepush concurrency + CI load.
+  mocha: {
+    timeout: 15000,
+    ui: 'bdd',
+    color: true,
+  },
 });


### PR DESCRIPTION
## Summary
Last piece of the v5.1.0 test-flake fight: the mocha timeout bump in src/test/suite/index.ts wasn't taking effect because `@vscode/test-cli` ignores `--extensionTestsPath` when `.vscode-test.mjs` exists.

## Root cause
The CLI's default mocha runner uses 2000ms. Prior fix only updated the custom runner that the CLI was bypassing.

## Fix
Add `mocha: { timeout: 15000 }` to `.vscode-test.mjs`.

## Test plan
- [x] Pre-push gate green
- [ ] CI Build & Test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)