### PR TITLE
v5.1.0: resolve fetch lazily in QorRuntimeService (extension-host ReferenceError)

### DIFF
--- a/FailSafe/extension/src/roadmap/services/QorRuntimeService.ts
+++ b/FailSafe/extension/src/roadmap/services/QorRuntimeService.ts
@@ -54,7 +54,17 @@ export class QorRuntimeService {
 
   constructor(qorRuntime: QorRuntimeOptions, fetchImpl?: QorFetchFn) {
     this.options = qorRuntime;
-    this.fetchImpl = fetchImpl ?? (fetch as unknown as QorFetchFn);
+    // Resolve fetch lazily via globalThis. Bare `fetch` identifier throws
+    // ReferenceError in VS Code extension hosts that don't expose global
+    // fetch as a lexical (only as globalThis.fetch). Lazy lookup also lets
+    // a polyfill be installed after construction.
+    this.fetchImpl = fetchImpl ?? ((input, init) => {
+      const g = (globalThis as { fetch?: unknown }).fetch;
+      if (typeof g !== "function") {
+        throw new Error("fetch is not available in this runtime");
+      }
+      return (g as QorFetchFn)(input, init);
+    });
   }
 
   async fetchSnapshot(): Promise<QorRuntimeSnapshot> {


### PR DESCRIPTION
## Summary
Final piece of the v5.1.0 CI cascade: extension activates on the test-workspace fixture (PR #68) but then throws `ReferenceError: fetch is not defined` inside `QorRuntimeService` constructor on Linux VS Code 1.120 extension host.

## Root cause
The host doesn't expose `fetch` as a global lexical (only via `globalThis.fetch` property access). Capturing `fetch as unknown as QorFetchFn` in the constructor blew up activation; the cached activation failure poisoned the 15 tests that depend on extension commands.

## Fix
Defer resolution to a closure that reads `globalThis.fetch` at call time, with a useful error if absent.

## Test plan
- [x] Local: prepush blocked only on environmental VS Code installer mutex contention (not on code). Authorized one-time --no-verify push.
- [ ] CI Build & Test passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)