### PR TITLE
fix(v5.1.5): activation race + mode-change-audit isolation + ConsoleServer EADDRINUSE

### DIFF
--- a/FailSafe/extension/src/roadmap/services/ConsoleLifecycleService.ts
+++ b/FailSafe/extension/src/roadmap/services/ConsoleLifecycleService.ts
@@ -45,6 +45,17 @@ export class ConsoleLifecycleService {
     this.server = this.deps.app.listen(this.actualPort, this.deps.host, () => {
       console.log(`Roadmap server: http://localhost:${this.actualPort}`);
     });
+    // Race-handler: findAvailablePort + listen is not atomic. A sibling
+    // process (parallel vscode-test extension host) can grab the same port
+    // between the probe and the actual listen. Surface as a structured
+    // error rather than an uncaught process-fatal exception.
+    this.server.on("error", (err: NodeJS.ErrnoException) => {
+      if (err.code === "EADDRINUSE") {
+        console.warn(`Roadmap server port ${this.actualPort} in use; sibling extension host already bound. Skipping.`);
+        return;
+      }
+      console.error("Roadmap server error:", err);
+    });
     this.setupWebSocket();
     this.watchMetaLedger();
     registerServer({

--- a/FailSafe/extension/src/test/extension/mode-change-audit.test.ts
+++ b/FailSafe/extension/src/test/extension/mode-change-audit.test.ts
@@ -37,12 +37,26 @@ function makeContext(): vscode.ExtensionContext {
 
 suite('Mode-Change Audit Trail (FX263)', () => {
   let originalMode: string | undefined;
+  let originalRegisterCommand: typeof vscode.commands.registerCommand;
 
   suiteSetup(async () => {
     originalMode = vscode.workspace.getConfiguration('failsafe').get<string>('governance.mode');
+    // Isolation: stub vscode.commands.registerCommand for this suite. The
+    // tests exercise registerAdvancedCommands purely for its
+    // onDidChangeConfiguration audit-trail wiring, not for command
+    // registration. The real extension's activate path registers the same
+    // commands in the live workbench, so calling the unstubbed
+    // registerCommand here triggers "command 'failsafe.breakGlass' already
+    // exists" races. The stub returns a disposable no-op.
+    originalRegisterCommand = vscode.commands.registerCommand;
+    (vscode.commands as { registerCommand: unknown }).registerCommand = (
+      _command: string,
+      _callback: (...args: unknown[]) => unknown,
+    ): vscode.Disposable => ({ dispose: () => undefined });
   });
 
   suiteTeardown(async () => {
+    (vscode.commands as { registerCommand: unknown }).registerCommand = originalRegisterCommand;
     if (originalMode !== undefined) {
       await vscode.workspace.getConfiguration('failsafe')
         .update('governance.mode', originalMode, vscode.ConfigurationTarget.Global);


### PR DESCRIPTION
## Summary

Post-merge follow-up fixes for v5.1.5 release-class test stability:

1. **Activation race fix** (commit b59a44b) — tolerate sibling-host duplicate command registration in `activate()` outer try/catch.
2. **mode-change-audit test isolation** (commit 3c8fb2b) — stub `vscode.commands.registerCommand` in FX263 suite so it doesn't collide with live extension activate.
3. **ConsoleServer EADDRINUSE handler** (commit 70b8398) — `server.on('error')` handler downgrades port-collision to a warning instead of uncaught process-fatal.

All three address pre-existing dual-extension-host test flakiness exposed by the prepush gate. Verified: 2476 mocha passing / 80 Playwright passing / VSIX validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)