### PR TITLE
fix(v5.1.6): repair test:all CI failure (25 failures)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ _Cycle pool open. Carry-over from v5.1.6: B-BIC-6/7/10/12/13/14/15/17/18 remaini
 
 ## [5.1.6] - 2026-05-20
 
-Bicameral HIGH cluster (B-BIC-16/19/20) + safety + concurrency batch (B-BIC-8/9/11/21/22/23) + upstream awareness (B-INT-3) + B-B199-2 Replay + Genome behavioral E2E + B-EM-2/B-EM-3 enforcement-mode polish. SHIELD-sealed via PR #77 (Entries #378/#379/#380) and PR #78 (Entry #382). See `docs/plan-qor-bicameral-cluster-high.md`, `docs/plan-qor-bicameral-safety-concurrency.md`, `docs/plan-qor-b199-2-replay-genome-e2e.md`, `docs/plan-qor-em-2-em-3-enforcement-mode-polish.md`.
+Bicameral HIGH cluster (B-BIC-16/19/20) + safety + concurrency batch (B-BIC-8/9/11/21/22/23) + upstream awareness (B-INT-3) + B-B199-2 Replay + Genome behavioral E2E + B-EM-2/B-EM-3 enforcement-mode polish + governance contract schemas (B190). SHIELD-sealed via PR #77 (Entries #378/#379/#380), PR #78 (Entry #382), and PR #79 (Entry #383). See `docs/plan-qor-bicameral-cluster-high.md`, `docs/plan-qor-bicameral-safety-concurrency.md`, `docs/plan-qor-b199-2-replay-genome-e2e.md`, `docs/plan-qor-em-2-em-3-enforcement-mode-polish.md`.
 
 ### Added
 
@@ -34,11 +34,16 @@ Bicameral HIGH cluster (B-BIC-16/19/20) + safety + concurrency batch (B-BIC-8/9/
 - **Runtime type guard on `callTool()` return** (B-BIC-23). All BicameralMcpClient call paths run the parsed payload through a runtime guard before returning, preventing malformed shapes from leaking into downstream consumers.
 - **Concurrent connect/disconnect race tests** (B-BIC-21). New test cases exercise interleaved `connect()` / `disconnect()` invocations to verify the in-flight cache + idle-disconnect interactions remain deterministic under contention.
 - **`semver.ts` shared helper**. `compareSemver` extracted from `upstream-row.ts` into a sibling module so the new `protocol-floor.ts` can share the same lightweight semver compare (returns -1/0/+1; strips `v` prefix; ignores pre-release tags). Restores Section 4 razor compliance for `upstream-row.ts`.
+- **Governance contract schemas** (B190). 8 JSON Schema 2020-12 contract definitions (`evaluation_request`, `ledger_entry`, `intent`, `failure_mode`, `approval`, `checkpoint`, `receipt`, `governance_config`) under `src/contracts/`, a typed `types.ts` surface with the `CONTRACT_VERSIONS` map, and fixture-match + well-formedness tests.
 
 ### Changed
 
 - **Audit cycle 1 → 2 remediation** (cluster-high plan). Six findings closed before implementation: (F1) `qorelogic.l3Decided` payload-shape citation drift, (F2) UpstreamMonitor SSRF allowlist enforcement before fetch, (F3) deferred-tool count contradiction reconciled (11 wrappers, not 12), (F4) DEFERRED/EXPIRED verdict no-op mapping clarified, (F5) FX528 SG-035 violation (stub → live subprocess), (F6) false-empty "Open Questions: None" replaced with explicit list.
 - **Safety + concurrency audit cycle 1 → 2 remediation**. APPROVE-WITH-MANDATORY-EDITS verdict closed via 3 must-fix + 2 should-fix items addressed inline. `BicameralMcpClient.ts` stands at 284L (over the 250-line razor by 34L); explicit exception documented in the audit since the 11 deferred-tool wrappers **are** the public API surface and extracting them would violate the type-surface contract.
+
+### Fixed
+
+- **Extension activation no longer crashes on hosts without a global `fetch`**. The B-INT-3 `UpstreamMonitor` was wired at activation time with the bare global `fetch`; on Node runtimes that do not expose `fetch`, this threw `ReferenceError` and aborted activation, leaving no `failsafe.*` commands registered. The HTTP transport is now feature-detected — falling back to a minimal `node:https` GET shim (`http-fetch-shim.ts`) — and the monitor wiring is isolated in a fail-safe `try/catch` so a non-critical background poller can never abort activation.
 
 ### Security
 

--- a/FailSafe/extension/src/extension/bootstrapBicameral.ts
+++ b/FailSafe/extension/src/extension/bootstrapBicameral.ts
@@ -14,6 +14,7 @@ import {
 } from "../integrations/bicameral";
 import { DriftToL3Mediator } from "../integrations/bicameral/DriftToL3Mediator";
 import { UpstreamMonitor } from "../integrations/bicameral/UpstreamMonitor";
+import { httpFetchShim } from "../integrations/bicameral/http-fetch-shim";
 import type { EventBus } from "../shared/EventBus";
 import type { Logger } from "../shared/Logger";
 import type { L3ApprovalRequest } from "../shared/types/l3-approval";
@@ -129,16 +130,48 @@ export function wireBicameralIntegration(
 
   // Phase 4: upstream monitor. Wired only when logger is present so error
   // paths can warn. configProvider falls back to defaults (24h poll,
-  // BicameralAI/bicameral-mcp). HTTP via global fetch (Node 18+).
+  // BicameralAI/bicameral-mcp).
+  //
+  // RC1: never let this non-critical 24h background poller abort extension
+  // activation. The whole construction is wrapped in try/catch, and the
+  // HTTP transport is feature-detected — the extension-host Node runtime
+  // does not reliably expose a global `fetch`, so we fall back to a tiny
+  // node:https GET shim that satisfies the subset of the Response API the
+  // UpstreamMonitor consumes.
   if (deps.logger && consoleServer.setUpstreamMonitor) {
+    wireUpstreamMonitor(context, consoleServer, deps.configProvider, deps.logger);
+  }
+}
+
+/**
+ * Construct + start the UpstreamMonitor. Isolated + fail-safe: any error here
+ * (bad config, transport init failure, future regression) is caught and
+ * logged — it must NEVER bubble up and abort extension activation, because
+ * the monitor is a non-critical background poller.
+ */
+function wireUpstreamMonitor(
+  context: vscode.ExtensionContext,
+  consoleServer: ConsoleServerSurface,
+  configProvider: ConfigProviderLike | undefined,
+  logger: Logger,
+): void {
+  try {
+    // RC1: feature-detect the global `fetch`. Falls back to the node:https
+    // shim on hosts (e.g. some vscode-test electron runtimes) that lack it.
+    const httpFetch: typeof fetch =
+      typeof fetch === "function" ? fetch : httpFetchShim;
     const monitor = new UpstreamMonitor({
-      httpFetch: fetch,
-      configProvider: deps.configProvider ?? {},
-      logger: deps.logger,
+      httpFetch,
+      configProvider: configProvider ?? {},
+      logger,
     });
     monitor.start();
-    consoleServer.setUpstreamMonitor(monitor);
+    consoleServer.setUpstreamMonitor?.(monitor);
     context.subscriptions.push({ dispose: () => monitor.dispose() });
+  } catch (err) {
+    logger.warn("UpstreamMonitor wiring skipped (non-critical)", {
+      error: err instanceof Error ? err.message : String(err),
+    });
   }
 }
 

--- a/FailSafe/extension/src/integrations/bicameral/BicameralMcpClient.ts
+++ b/FailSafe/extension/src/integrations/bicameral/BicameralMcpClient.ts
@@ -52,6 +52,10 @@ interface BicameralMcpClientOptions {
   command: string;
   args?: string[];
   cwd: string;
+  /** Extra environment variables for the spawned MCP server process. Merged
+   *  into the SDK's default-inherited env. Needed e.g. to set
+   *  ELECTRON_RUN_AS_NODE when `command` is an Electron binary. */
+  env?: Record<string, string>;
   /** B-BIC-9: idle disconnect TTL in ms. 0 disables. Default 900_000 (15min). */
   idleDisconnectMs?: number;
   /** Test seam: override the underlying MCP client (mocks). */
@@ -105,6 +109,9 @@ export class BicameralMcpClient {
           command: this.opts.command,
           args: this.opts.args ?? [],
           cwd: this.opts.cwd,
+          // StdioClientTransport restricts inherited env to an allowlist; any
+          // extra vars (e.g. ELECTRON_RUN_AS_NODE) must be passed explicitly.
+          ...(this.opts.env ? { env: this.opts.env } : {}),
         });
     const client = this.opts.clientFactory
       ? this.opts.clientFactory()

--- a/FailSafe/extension/src/integrations/bicameral/http-fetch-shim.ts
+++ b/FailSafe/extension/src/integrations/bicameral/http-fetch-shim.ts
@@ -1,0 +1,54 @@
+// http-fetch-shim — minimal `fetch`-shaped GET helper backed by node:https.
+//
+// RC1: the extension-host Node runtime (vscode-test electron) does not
+// reliably expose a global `fetch`. `UpstreamMonitor` only issues GET
+// requests to api.github.com and consumes a tiny subset of the Response
+// API (`.ok`, `.status`, `.json()`). This shim satisfies exactly that
+// subset so the upstream poller keeps working when global `fetch` is
+// absent — graceful degradation without bricking activation.
+//
+// Intentionally minimal: GET only, HTTPS only, no streaming, no headers
+// API beyond what UpstreamMonitor needs. Not a general-purpose fetch.
+
+import * as https from 'node:https';
+
+/** The slice of the WHATWG Response interface that UpstreamMonitor consumes. */
+interface MinimalResponse {
+  ok: boolean;
+  status: number;
+  json(): Promise<unknown>;
+  text(): Promise<string>;
+}
+
+/**
+ * A `typeof fetch`-compatible GET shim. Only the first argument (URL) is
+ * honoured; request init is ignored because UpstreamMonitor issues bare
+ * GETs. Resolves with a MinimalResponse; rejects on transport error.
+ */
+export const httpFetchShim: typeof fetch = ((input: RequestInfo | URL): Promise<Response> => {
+  const url = typeof input === 'string' ? input : input.toString();
+  return new Promise<Response>((resolve, reject) => {
+    const req = https.get(
+      url,
+      // GitHub's REST API rejects requests without a User-Agent.
+      { headers: { 'User-Agent': 'failsafe-upstream-monitor', Accept: 'application/vnd.github+json' } },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (c: Buffer) => chunks.push(c));
+        res.on('end', () => {
+          const body = Buffer.concat(chunks).toString('utf8');
+          const status = res.statusCode ?? 0;
+          const response: MinimalResponse = {
+            ok: status >= 200 && status < 300,
+            status,
+            json: async () => JSON.parse(body),
+            text: async () => body,
+          };
+          resolve(response as unknown as Response);
+        });
+      },
+    );
+    req.on('error', reject);
+    req.end();
+  });
+}) as typeof fetch;

--- a/FailSafe/extension/src/test/integrations/bicameral/echo-mcp-server.test.ts
+++ b/FailSafe/extension/src/test/integrations/bicameral/echo-mcp-server.test.ts
@@ -27,10 +27,21 @@ suite('BicameralMcpClient against vendored echo-mcp-server (FX528)', function ()
       command: process.execPath,
       args: [ECHO_SERVER_JS],
       cwd: sideChannelDir,
+      // FX528/RC3: under vscode-test, process.execPath is the Electron
+      // binary. Spawned without ELECTRON_RUN_AS_NODE it boots the Electron
+      // GUI runtime instead of running echo-mcp-server.js as a Node script,
+      // so the MCP stdio handshake never completes ("Connection closed").
+      // ELECTRON_RUN_AS_NODE=1 makes the Electron binary behave as plain Node.
+      // StdioClientTransport strips inherited env to an allowlist, so PATH +
+      // ECHO_MCP_SIDE_CHANNEL must also be passed through explicitly.
+      env: {
+        ELECTRON_RUN_AS_NODE: '1',
+        ECHO_MCP_SIDE_CHANNEL: path.join(sideChannelDir, 'echo-mcp-server.last-call.json'),
+        ...(process.env.PATH ? { PATH: process.env.PATH } : {}),
+        ...(process.env.SystemRoot ? { SystemRoot: process.env.SystemRoot } : {}),
+      },
       // No factory overrides: real Client + StdioClientTransport.
     });
-    // Inject side-channel path via env on the spawned process. StdioClientTransport
-    // does not expose env passthrough; the test relies on cwd-relative default.
   });
 
   teardown(async () => {

--- a/FailSafe/extension/src/test/integrations/bicameral/echo-mcp-server.ts
+++ b/FailSafe/extension/src/test/integrations/bicameral/echo-mcp-server.ts
@@ -56,8 +56,12 @@ const CANNED: Record<string, unknown> = {
   'bicameral.getNeighbors': { neighbors: [] },
 };
 
+// FX528/RC3: version must sit within the supported upstream range
+// (>=0.14, <0.16). B-BIC-22's assertBicameralProtocolFloor tears down the
+// connection — surfacing as "Connection closed" to the client — when the
+// reported version is below MIN_BICAMERAL_VERSION. '0.0.0' fails the floor.
 const server = new Server(
-  { name: 'echo-bicameral', version: '0.0.0' },
+  { name: 'echo-bicameral', version: '0.15.0' },
   { capabilities: { tools: {} } },
 );
 

--- a/FailSafe/extension/src/test/integrations/bicameral/install-handler.test.ts
+++ b/FailSafe/extension/src/test/integrations/bicameral/install-handler.test.ts
@@ -4,7 +4,7 @@
 
 import { strict as assert } from 'assert';
 import { EventEmitter } from 'events';
-import { runBicameralInstall } from '../../../integrations/bicameral/install-handler';
+import { runBicameralInstall, BICAMERAL_PIP_SPEC } from '../../../integrations/bicameral/install-handler';
 import { InstallProgressEvent, BicameralInstallState } from '../../../integrations/bicameral/types';
 
 interface SpawnCall { bin: string; args: string[]; opts: Record<string, unknown>; }
@@ -52,7 +52,10 @@ suite('integrations/bicameral install-handler', () => {
     }, 'solo');
     assert.equal(spawnFake.calls.length, 2);
     assert.equal(spawnFake.calls[0].bin, 'pip');
-    assert.deepEqual(spawnFake.calls[0].args, ['install', 'bicameral-mcp']);
+    // RC2 / B-INT-3: pip install is pinned to the version-bounded spec, not the
+    // bare package name. Assert against the exported constant so the test
+    // tracks the product's pin and cannot drift again.
+    assert.deepEqual(spawnFake.calls[0].args, ['install', BICAMERAL_PIP_SPEC]);
     assert.equal(spawnFake.calls[0].opts.shell, false);
     assert.equal(spawnFake.calls[1].bin, 'bicameral-mcp');
     assert.deepEqual(spawnFake.calls[1].args, ['setup', '--mode', 'solo']);

--- a/FailSafe/extension/src/test/roadmap/BicameralRoute.upstream.test.ts
+++ b/FailSafe/extension/src/test/roadmap/BicameralRoute.upstream.test.ts
@@ -20,6 +20,25 @@ function makeDeps(overrides: Partial<BicameralRouteDeps> = {}): BicameralRouteDe
   };
 }
 
+/** RC1: node:http GET helper — the test must not depend on a global `fetch`,
+ *  which the vscode-test electron extension-host runtime does not reliably
+ *  expose. Mirrors the fetchJson pattern in src/test/ui/bus-renderer-flow.spec.ts. */
+async function httpGet(url: string): Promise<{ status: number; json(): Promise<unknown> }> {
+  return new Promise((resolve, reject) => {
+    http.get(url, (res) => {
+      const chunks: Buffer[] = [];
+      res.on('data', (c) => chunks.push(c));
+      res.on('end', () => {
+        const body = Buffer.concat(chunks).toString('utf-8');
+        resolve({
+          status: res.statusCode ?? 0,
+          json: async () => JSON.parse(body),
+        });
+      });
+    }).on('error', reject);
+  });
+}
+
 async function startServer(deps: BicameralRouteDeps): Promise<{ url: string; close: () => Promise<void> }> {
   const app = express();
   app.use(express.json());
@@ -45,7 +64,7 @@ suite('BicameralRoute upstream (FX533)', () => {
     const deps = makeDeps({ upstreamMonitor: { getSnapshot: () => snapshot } });
     const server = await startServer(deps);
     try {
-      const resp = await fetch(`${server.url}/api/integrations/bicameral/upstream`);
+      const resp = await httpGet(`${server.url}/api/integrations/bicameral/upstream`);
       assert.equal(resp.status, 200);
       const body = await resp.json() as { ok: boolean; snapshot: UpstreamSnapshot };
       assert.equal(body.ok, true);
@@ -60,7 +79,7 @@ suite('BicameralRoute upstream (FX533)', () => {
     const deps = makeDeps({ upstreamMonitor: { getSnapshot: () => null } });
     const server = await startServer(deps);
     try {
-      const resp = await fetch(`${server.url}/api/integrations/bicameral/upstream`);
+      const resp = await httpGet(`${server.url}/api/integrations/bicameral/upstream`);
       assert.equal(resp.status, 503);
       const body = await resp.json() as { ok: boolean; error: string };
       assert.equal(body.ok, false);
@@ -74,7 +93,7 @@ suite('BicameralRoute upstream (FX533)', () => {
     const deps = makeDeps(); // upstreamMonitor omitted
     const server = await startServer(deps);
     try {
-      const resp = await fetch(`${server.url}/api/integrations/bicameral/upstream`);
+      const resp = await httpGet(`${server.url}/api/integrations/bicameral/upstream`);
       assert.equal(resp.status, 503);
       const body = await resp.json() as { ok: boolean; error: string };
       assert.match(body.error, /not wired/);
@@ -96,7 +115,7 @@ suite('BicameralRoute upstream (FX533)', () => {
     });
     const server = await startServer(deps);
     try {
-      const resp = await fetch(`${server.url}/api/integrations/bicameral/upstream`);
+      const resp = await httpGet(`${server.url}/api/integrations/bicameral/upstream`);
       assert.equal(resp.status, 403);
       assert.equal(monitorCalled, false, 'rejectIfRemote must short-circuit before monitor read');
     } finally {


### PR DESCRIPTION
## Summary

The v5.1.6 Release Pipeline (run 26240562211) failed `test:all` with **25 failures**, skipping both publish jobs — v5.1.6 never published. Root-caused via `/qor-debug` to three independent defects:

- **RC1 (product defect)** — `UpstreamMonitor` (B-INT-3) was wired at extension activation with the bare global `fetch`. Node hosts without a global `fetch` threw `ReferenceError`, aborting activation → no `failsafe.*` commands registered → **19 failures** (incl. 14 collateral "command not found"). Fix: feature-detect `fetch` with a `node:https` GET shim fallback (`http-fetch-shim.ts`); isolate the monitor wiring in a fail-safe `try/catch`.
- **RC2 (test)** — `install-handler.test.ts` asserted the pre-B-INT-3 pip args; now asserts against the `BICAMERAL_PIP_SPEC` product constant (**1 failure**).
- **RC3 (test)** — the `echo-mcp-server` fixture spawned the Electron binary without `ELECTRON_RUN_AS_NODE` and reported a version below the B-BIC-22 protocol floor. Fix: pass `ELECTRON_RUN_AS_NODE=1`; bump the fixture to `0.15.0` (**5 failures**).

Also folds **B190 governance contracts** (PR #79, merged to `main` after the original v5.1.6 tag) into the CHANGELOG `[5.1.6]` section, since the re-tag will sit on current `main`.

## Verification

- `tsc` clean; `bootstrapBicameral.ts` 203 lines (under the 250 Razor).
- RC1 `BicameralRoute.upstream` 4/4, RC2 `install-handler` 14/14, RC3 `echo-mcp-server` 5/5 — all pass via mocha.
- Regression specs `protocolFloor` 5/5, `connectRace` 4/4 still pass.
- `httpFetchShim` driven end-to-end against the live GitHub API — valid snapshot, 0 warnings.
- Full local `test:all` electron suite blocked by an environment file-lock (running VS Code holds `better-sqlite3`); the authoritative full-suite run is this pipeline on re-tag.

## Test plan

- [ ] PR CI checks pass
- [ ] After merge: re-cut `v5.1.6` tag on `main` → Release Pipeline `validate` + `build` (`test:all`) green
- [ ] Approve `production` environment → publish to VS Code Marketplace + Open VSX

🤖 Generated with [Claude Code](https://claude.com/claude-code)