### PR TITLE
fix(voice-pack): drop --force-local for BSD tar portability

### DIFF
--- a/FailSafe/extension/scripts/package-voice-pack.cjs
+++ b/FailSafe/extension/scripts/package-voice-pack.cjs
@@ -103,11 +103,23 @@ function writeManifest(stagingDir, version, collected) {
 
 function runTarCreate(stagingDir, tarballPath) {
   const entries = fs.readdirSync(stagingDir);
-  // --force-local: tells GNU tar / Cygwin tar to treat Windows-style paths
-  // with drive letters (e.g., G:\...) as local filenames rather than as
-  // `host:path` SSH remotes. Windows 10+ built-in tar.exe accepts the flag.
-  const args = ['--force-local', '-czf', tarballPath, '-C', stagingDir, ...entries];
-  const result = spawnSync('tar', args, { shell: false, encoding: 'utf8' });
+  // Portability: BSD tar (macOS default) and bsdtar do NOT accept
+  // `--force-local`, which previously broke `npm test` on those hosts. The
+  // flag was needed because a Windows drive-letter path like
+  // `G:\MythologIQ\…\foo.tar.gz` is otherwise interpreted as a `host:path`
+  // SSH remote. The portable fix is to never pass a `:`-bearing path to
+  // tar at all: cwd into the tarball's directory and pass just the
+  // basename for `-czf`. `-C stagingDir` is unaffected (tar resolves it
+  // relative to its own cwd, and on every platform a directory path with
+  // no `:` is unambiguous).
+  const tarballDir = path.dirname(tarballPath);
+  const tarballName = path.basename(tarballPath);
+  const args = ['-czf', tarballName, '-C', stagingDir, ...entries];
+  const result = spawnSync('tar', args, {
+    shell: false,
+    encoding: 'utf8',
+    cwd: tarballDir,
+  });
   if (result.status !== 0) {
     throw new Error(`tar -czf failed (exit ${result.status}): ${result.stderr.trim()}`);
   }


### PR DESCRIPTION
## Summary

`package-voice-pack.cjs` previously passed `--force-local` to `tar` to prevent Windows drive-letter paths (`G:\...`) from being misinterpreted as `host:path` SSH remotes. **GNU tar** (Linux) and **Windows 10+ built-in tar.exe** accept the flag; **BSD tar** (macOS default) and **bsdtar** reject it as unknown, which broke `npm test` on those hosts via the `package:voice-pack` prepackage hook:

```
tar: Option --force-local is not supported
```

## Fix

Never pass a `:`-bearing path to tar at all. Set `cwd: path.dirname(tarballPath)` on the spawn and pass only `path.basename(tarballPath)` for `-czf`. `-C stagingDir` is unaffected — tar resolves the change-dir relative to its own cwd, and a directory path with no `:` is unambiguous on every platform.

## Verification

Windows host (built-in tar.exe):
- Stubbed `dist/extension/ui/vendor/{piper,whisper}/*` fixtures
- `node scripts/package-voice-pack.cjs` → tarball written, files: 2
- `tar -tzf dist/failsafe-voice-pack-5.1.8.tar.gz` → \`piper/\`, \`piper/piper.exe\`, \`voice-pack.manifest.json\`, \`whisper/\`, \`whisper/whisper.bin\`
- sha256 sidecar generated

macOS verification deferred to operator — the host where the reviewer originally hit the BSD-tar error. Expected: same output with no `Option --force-local is not supported` message.

## Scope

Single file change in `FailSafe/extension/scripts/package-voice-pack.cjs`. No application code touched. No new dependencies. No tests added (this is a build script invoking the system tar binary; the functional invocation above IS the test).

🤖 Generated with [Claude Code](https://claude.com/claude-code)