### PR TITLE
fix(ci): test:all on PRs to main + bold Integrations showcase in READMEs

### DIFF
--- a/.github/workflows/pr-full-test.yml
+++ b/.github/workflows/pr-full-test.yml
@@ -1,0 +1,45 @@
+name: PR Full Test
+
+# Runs the complete test suite (lint + extension-host mocha + Playwright UI,
+# including the better-sqlite3 native rebuild against the PINNED VS Code version)
+# on every PR targeting main. Before this gate, `test:all` ran ONLY on the
+# Release Pipeline (tag push), so native-build and UI-test regressions were
+# invisible until a tag fired — the exact gap that dead-tagged v5.4.0 (a stale
+# Integrations pill-count Playwright assertion that the standards-only PR gate
+# never exercised). Running it here surfaces those failures at PR time, before
+# they reach main and before any release tag.
+on:
+  pull_request:
+    branches: [main]
+
+# A newer push to the same PR cancels the in-flight run (the full suite is slow;
+# no value finishing a stale commit).
+concurrency:
+  group: pr-full-test-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  full-test:
+    name: Full Test Suite (test:all)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+        working-directory: FailSafe/extension
+      - run: npx playwright install --with-deps chromium
+        working-directory: FailSafe/extension
+      - run: npm run compile
+        working-directory: FailSafe/extension
+      - run: xvfb-run -a npm run test:all
+        working-directory: FailSafe/extension
+      - name: Upload Playwright report on failure
+        if: ${{ failure() && hashFiles('FailSafe/extension/playwright-report/**') != '' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: FailSafe/extension/playwright-report/
+          if-no-files-found: ignore
+          retention-days: 14

--- a/FailSafe/extension/README.md
+++ b/FailSafe/extension/README.md
@@ -14,14 +14,20 @@ FailSafe runs locally inside VS Code and Cursor. It monitors what AI agents do, 
 
 ---
 
-## 🧩 Integration Beta — Bicameral MCP + Open Design
+## 🔌 Integrations — govern your entire AI toolchain, not just the editor
 
-**FailSafe now connects to best-in-class design & decision tools — Bicameral MCP + Open Design in beta, and (new in v5.4.0) governed one-click installers for Context7 + Mermaid Chart MCP.**
+FailSafe v5.4 turns the editor into a **governance hub** for the tools your AI agents actually use. Every integration is **local-first, opt-in, and routed through the same deterministic policy engine** that guards your edits — so connecting a tool never widens your attack surface or sends data anywhere by default.
 
-- **🧠 Bicameral MCP** — bring your architecture *decisions* and their drift into the Command Center. Detect, connect, and ratify decision records inline; every Bicameral tool call is governed through FailSafe's universal interceptor.
-- **🎨 Open Design** — observe Open Design agent runs **and now act on them**: the new L3-gated `create_artifact` lets FailSafe create design artifacts only with explicit human approval (Buffer & auto-execute). Destructive write tools stay locked by design.
+| Integration | What it does | Why it matters |
+|---|---|---|
+| 🛡️ **SARIF security ingestion** | Import Semgrep / CodeQL / any SARIF 2.1.0 scanner output into the risk register (`FailSafe: Import SARIF Findings`). | Your security scanner stops being a separate silo — every finding becomes a *governed* risk in the same audit trail as agent decisions. One source of truth for security **and** AI governance. |
+| 🧮 **MCP Registry risk scoring** | Score any MCP server locally — read-only, with field sanitization — before you trust it. | The MCP ecosystem is exploding and anything can claim to be a tool server. Adopt servers on **evidence, not vibes** — a supply-chain admission check at the door. |
+| 📣 **Slack governance notifications** | Post VETO / L3-approval / drift events to a Slack webhook. Notify-only, off by default. | Governance becomes a **team** signal: when FailSafe blocks a risky action or queues a human approval, the right people see it in their channel — without anyone watching the editor. |
+| 📦 **MCP Catalog installers** | One-click, risk-scored installs of **Context7** (live library docs) and **Mermaid Chart** (diagrams) into your `.mcp.json` — new **Integrations → MCP Catalog** tab (`FailSafe: Install MCP Integration (governed)`). | No hand-editing config, no guesswork — governed installs of tools that make your agents measurably better, with the trust check built in. |
+| 🧠 **Bicameral MCP** | Detect, connect, and ratify architecture *decision* records and their drift inline. | Every Bicameral tool call passes through FailSafe's universal interceptor — the reasoning behind your system stays as governed as the code. |
+| 🎨 **Open Design** | Observe Open Design agent runs and act on them via the L3-gated `create_artifact` (Buffer & auto-execute; destructive writes stay locked). | Design tooling gets the same human-in-the-loop guarantee as everything else FailSafe touches. |
 
-Both are **opt-in and local-first** — disabled by default, no network until you enable them. Open the **Integrations** tab to connect. Feedback welcome while these mature out of beta.
+**Everything above is disabled by default and runs locally — no network call until you turn one on.** Open the **Integrations** tab to connect.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -30,14 +30,20 @@ _Local-first safety for AI coding assistants._
 
 ---
 
-## 🧩 Integration Beta — Bicameral MCP + Open Design
+## 🔌 Integrations — govern your entire AI toolchain, not just the editor
 
-**FailSafe now connects to best-in-class design & decision tools — Bicameral MCP + Open Design in beta, and (new in v5.4.0) governed one-click installers for Context7 + Mermaid Chart MCP.**
+FailSafe v5.4 turns the editor into a **governance hub** for the tools your AI agents actually use. Every integration is **local-first, opt-in, and routed through the same deterministic policy engine** that guards your edits — so connecting a tool never widens your attack surface or sends data anywhere by default.
 
-- **🧠 Bicameral MCP** — bring your architecture *decisions* and their drift into the Command Center. Detect, connect, and ratify decision records inline; every Bicameral tool call is governed through FailSafe's universal interceptor.
-- **🎨 Open Design** — observe Open Design agent runs **and now act on them**: the new L3-gated `create_artifact` lets FailSafe create design artifacts only with explicit human approval (Buffer & auto-execute). Destructive write tools stay locked by design.
+| Integration | What it does | Why it matters |
+|---|---|---|
+| 🛡️ **SARIF security ingestion** | Import Semgrep / CodeQL / any SARIF 2.1.0 scanner output into the risk register (`FailSafe: Import SARIF Findings`). | Your security scanner stops being a separate silo — every finding becomes a *governed* risk in the same audit trail as agent decisions. One source of truth for security **and** AI governance. |
+| 🧮 **MCP Registry risk scoring** | Score any MCP server locally — read-only, with field sanitization — before you trust it. | The MCP ecosystem is exploding and anything can claim to be a tool server. Adopt servers on **evidence, not vibes** — a supply-chain admission check at the door. |
+| 📣 **Slack governance notifications** | Post VETO / L3-approval / drift events to a Slack webhook. Notify-only, off by default. | Governance becomes a **team** signal: when FailSafe blocks a risky action or queues a human approval, the right people see it in their channel — without anyone watching the editor. |
+| 📦 **MCP Catalog installers** | One-click, risk-scored installs of **Context7** (live library docs) and **Mermaid Chart** (diagrams) into your `.mcp.json` — new **Integrations → MCP Catalog** tab (`FailSafe: Install MCP Integration (governed)`). | No hand-editing config, no guesswork — governed installs of tools that make your agents measurably better, with the trust check built in. |
+| 🧠 **Bicameral MCP** | Detect, connect, and ratify architecture *decision* records and their drift inline. | Every Bicameral tool call passes through FailSafe's universal interceptor — the reasoning behind your system stays as governed as the code. |
+| 🎨 **Open Design** | Observe Open Design agent runs and act on them via the L3-gated `create_artifact` (Buffer & auto-execute; destructive writes stay locked). | Design tooling gets the same human-in-the-loop guarantee as everything else FailSafe touches. |
 
-Both are **opt-in and local-first** — disabled by default, no network until you enable them. Find them under the **Integrations** tab. Feedback welcome while these mature out of beta.
+**Everything above is disabled by default and runs locally — no network call until you turn one on.** Open the **Integrations** tab to connect.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Switch modes via the `FailSafe: Set Governance Mode` command or the `failsafe.go
 
 ## Qor-Logic: The Governance Layer
 
-Qor-Logic is the deterministic governance engine that enforces safety policies at the editor boundary. It operates on a fundamental principle: **governance decisions are made by code, not by asking an LLM to follow rules.**
+Qor-Logic is two things working as one: the **deterministic governance engine** that enforces safety policies at the editor boundary, and the **SHIELD skill corpus** — sourced from the [`qor-logic`](https://pypi.org/project/qor-logic/) PyPI package — that drives a governed _plan → audit → implement → substantiate → deliver_ lifecycle for AI-assisted work. Both rest on one principle: **governance decisions are made by code, not by asking an LLM to follow rules.**
 
 ### Prompt Guidelines vs. Deterministic Governance
 
@@ -363,6 +363,8 @@ Qor-Logic is the deterministic governance engine that enforces safety policies a
    - Approved L3 actions → trust increase
    - Rejected or failed actions → trust decrease
    - Trust scores influence future routing decisions
+
+5. **Universal Interception** — The same deterministic boundary governs more than file edits. Every MCP tool call from a connected integration (Bicameral, Open Design, MCP Catalog servers) is routed through a single `IGovernanceInterceptor` seam, so a risky _tool invocation_ is classified, gated, and ledgered exactly like a risky _edit_. Governance follows the agent wherever it acts.
 
 ### Why Deterministic Matters
 


### PR DESCRIPTION
Two changes from the v5.4.2 close-out follow-ups.

## CI gate — `test:all` on PRs to main (`.github/workflows/pr-full-test.yml`)
Closes the dead-tag gap. `test:all` (lint + extension-host mocha + Playwright UI + the `better-sqlite3` native rebuild against the **pinned** VS Code version) previously ran **only** on the Release Pipeline (tag push), so the v5.4.0 stale Integrations pill-count regression was invisible until the tag fired. This runs the full suite on every PR to main — the regression would have failed its *feat* PR before reaching main.

- `concurrency` cancels superseded runs; Playwright report uploaded on failure.
- **This PR self-tests the gate** — the new `Full Test Suite (test:all)` check runs against this very PR.
- Recommend adding it as a required status check in branch protection (repo-settings step, separate).

## Docs — bold Integrations showcase (`/qor-document`)
Replaces the thin "Integration Beta" blurb in both marketplace READMEs (extension + root) with a value-driven showcase table: SARIF ingestion, MCP Registry scoring, Slack notifications, MCP Catalog installers (Context7 + Mermaid), Bicameral, Open Design — each with a *what* + *why-it-matters*. Every claim back-cited to shipped v5.4.2 code (command titles, Slack events, defaults verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)