### PR TITLE
feat(mcp-catalog): Playwright MCP as a governed high-risk catalog entry (B-INT-15)

### DIFF
--- a/FailSafe/extension/src/integrations/mcp-catalog/mcp-catalog.ts
+++ b/FailSafe/extension/src/integrations/mcp-catalog/mcp-catalog.ts
@@ -1,9 +1,12 @@
 /**
  * mcp-catalog — curated, governed catalog of installable MCP integrations
- * (B-INT-13 Context7 + B-INT-14 Mermaid Chart). These are "installer-only"
- * integrations: standard MCP servers whose value is registering them into the
- * workspace MCP config under FailSafe governance. Each entry carries the
- * McpServerMeta consumed by the #108 risk scorer, so admission is risk-rated.
+ * (B-INT-13 Context7 + B-INT-14 Mermaid Chart + B-INT-15 Playwright). These are
+ * "installer-only" integrations: standard MCP servers whose value is registering
+ * them into the workspace MCP config under FailSafe governance. Each entry
+ * carries the McpServerMeta consumed by the #108 risk scorer, so admission is
+ * risk-rated — and a high-capability server (Playwright: browser automation +
+ * arbitrary in-page JS via browser_evaluate) is surfaced as `high` risk, exactly
+ * the governance value of curating installs through FailSafe.
  *
  * Install commands are verified (not fabricated): see docs/INTEGRATIONS.md.
  * Pure — no fs/network — so the catalog + its risk assessment are unit-tested.
@@ -39,6 +42,24 @@ export const MCP_CATALOG: McpCatalogEntry[] = [
       transports: ['stdio'], tools: [{ name: 'validate_and_render_mermaid_diagram' }],
     },
     install: { command: 'npx', args: ['-y', 'mcp-mermaid'], transport: 'stdio', note: 'Community render/validate package; the official Mermaid Chart hosted server is an alternative.' },
+  },
+  {
+    id: 'playwright',
+    name: 'Playwright',
+    description: 'Browser automation for agents via accessibility snapshots — navigate, click, type, fill forms, inspect/mock network. A high-capability surface FailSafe rates HIGH risk: review the safe-flag guidance before you trust it.',
+    meta: {
+      name: 'playwright', publisher: 'Microsoft', repositoryUrl: 'https://github.com/microsoft/playwright-mcp',
+      transports: ['stdio'],
+      tools: [
+        { name: 'browser_navigate' }, { name: 'browser_click' }, { name: 'browser_type' },
+        { name: 'browser_evaluate' }, { name: 'browser_file_upload' }, { name: 'browser_network_requests' },
+        { name: 'browser_take_screenshot' },
+      ],
+    },
+    install: {
+      command: 'npx', args: ['-y', '@playwright/mcp@latest'], transport: 'stdio',
+      note: 'High-capability browser automation — Microsoft states Playwright MCP is NOT a security boundary, and browser_evaluate runs arbitrary JS in the page. Prefer --isolated (in-memory profile) + --headless; opt into extra powers only via --caps; never pass --no-sandbox with untrusted content.',
+    },
   },
 ];
 

--- a/FailSafe/extension/src/test/integrations/mcp-catalog/mcp-catalog.test.ts
+++ b/FailSafe/extension/src/test/integrations/mcp-catalog/mcp-catalog.test.ts
@@ -5,28 +5,48 @@ import { mergeMcpConfig, buildMcpServerEntry } from '../../../integrations/mcp-c
 const NOW = new Date('2026-06-02T00:00:00Z');
 
 suite('mcp-catalog + installer (B-INT-13/14)', () => {
-  test('catalog has Context7 + Mermaid with verified npx install commands', () => {
+  test('catalog has Context7 + Mermaid + Playwright with verified npx install commands', () => {
     const ids = MCP_CATALOG.map((e) => e.id).sort();
-    assert.deepEqual(ids, ['context7', 'mermaid']);
+    assert.deepEqual(ids, ['context7', 'mermaid', 'playwright']);
     const c7 = MCP_CATALOG.find((e) => e.id === 'context7')!;
     assert.deepEqual(c7.install.args, ['-y', '@upstash/context7-mcp']);
     const mer = MCP_CATALOG.find((e) => e.id === 'mermaid')!;
     assert.deepEqual(mer.install.args, ['-y', 'mcp-mermaid']);
+    const pw = MCP_CATALOG.find((e) => e.id === 'playwright')!;
+    assert.deepEqual(pw.install.args, ['-y', '@playwright/mcp@latest']);
   });
 
-  test('assessCatalog risk-rates each entry (both low: publisher+repo+stdio, no dangerous tools)', () => {
+  test('assessCatalog risk-rates each entry (read-only servers low; Playwright high via code-eval tool)', () => {
     const a = assessCatalog(NOW);
-    assert.equal(a.length, 2);
-    for (const { assessment } of a) {
-      assert.equal(assessment.level, 'low');
-      // only unknown-recency (no publish date) — never a high signal.
-      assert.ok(!assessment.signals.some((s) => s.severity === 'high'));
+    assert.equal(a.length, 3);
+    const byId = Object.fromEntries(a.map(({ entry, assessment }) => [entry.id, assessment]));
+    // Read-only doc/diagram servers: low risk, never a high signal.
+    for (const id of ['context7', 'mermaid']) {
+      assert.equal(byId[id].level, 'low', `${id} should be low`);
+      assert.ok(!byId[id].signals.some((s) => s.severity === 'high'));
     }
+    // Playwright: high-capability browser automation → high, flagged on its
+    // code-evaluation tool (browser_evaluate matches the dangerous-tool rule),
+    // and it must out-score the read-only entries.
+    assert.equal(byId['playwright'].level, 'high');
+    assert.ok(
+      byId['playwright'].signals.some((s) => s.id === 'broad-tool-names' && s.severity === 'high'),
+      'Playwright must carry the broad-tool-names high signal (browser_evaluate)',
+    );
+    assert.ok(byId['playwright'].score > byId['context7'].score, 'Playwright out-scores read-only Context7');
   });
 
   test('buildMcpServerEntry yields the .mcp.json command/args shape', () => {
     const c7 = MCP_CATALOG.find((e) => e.id === 'context7')!;
     assert.deepEqual(buildMcpServerEntry(c7), { command: 'npx', args: ['-y', '@upstash/context7-mcp'] });
+  });
+
+  test('Playwright installs under mcpServers.playwright with the verified args', () => {
+    const pw = MCP_CATALOG.find((e) => e.id === 'playwright')!;
+    assert.deepEqual(buildMcpServerEntry(pw), { command: 'npx', args: ['-y', '@playwright/mcp@latest'] });
+    const { text, added } = mergeMcpConfig('', pw);
+    assert.equal(added, true);
+    assert.deepEqual(JSON.parse(text).mcpServers.playwright, { command: 'npx', args: ['-y', '@playwright/mcp@latest'] });
   });
 
   test('mergeMcpConfig: empty → adds under mcpServers (added=true, valid JSON)', () => {

--- a/FailSafe/extension/src/test/roadmap/mcp-catalog-renderer.test.ts
+++ b/FailSafe/extension/src/test/roadmap/mcp-catalog-renderer.test.ts
@@ -43,6 +43,23 @@ suite('McpCatalogRenderer (B-INT-13/14, jsdom structural)', () => {
     } finally { ctx.cleanup(); }
   });
 
+  test('renders the high-risk badge for a high-capability entry (Playwright)', async () => {
+    const HIGH_CATALOG = {
+      entries: [
+        { id: 'playwright', name: 'Playwright', description: 'browser automation', install: { command: 'npx', args: ['-y', '@playwright/mcp@latest'] }, risk: { level: 'high', score: 4, signals: [{ id: 'broad-tool-names', severity: 'high', detail: 'browser_evaluate' }] } },
+      ],
+    };
+    const ctx = setupDom(async () => ({ ok: true, json: async () => HIGH_CATALOG }));
+    try {
+      await new McpCatalogRenderer('integrations').render();
+      // The governance payoff: a high-capability server surfaces a HIGH risk badge,
+      // not a generic/low one.
+      assert.equal(ctx.doc.querySelectorAll('.cc-mcp-risk-high').length, 1, 'high-risk badge renders');
+      assert.equal(ctx.doc.querySelectorAll('.cc-mcp-risk-low').length, 0);
+      assert.ok(ctx.doc.body.innerHTML.includes('@playwright/mcp@latest'));
+    } finally { ctx.cleanup(); }
+  });
+
   test('install button is confirm-then-POST (no silent install)', async () => {
     const calls: string[] = [];
     const ctx = setupDom(async (url: string) => {

--- a/FailSafe/extension/src/test/roadmap/routes/McpRoute.test.ts
+++ b/FailSafe/extension/src/test/roadmap/routes/McpRoute.test.ts
@@ -20,9 +20,12 @@ suite('McpRoute (B-INT-13/14 UI backing)', () => {
     const r = res();
     McpRoute.catalog({} as never, r as never);
     const body = r.body as { entries: Array<{ id: string; risk: { level: string } }> };
-    assert.equal(body.entries.length, 2);
-    assert.deepEqual(body.entries.map((e) => e.id).sort(), ['context7', 'mermaid']);
+    assert.equal(body.entries.length, 3);
+    assert.deepEqual(body.entries.map((e) => e.id).sort(), ['context7', 'mermaid', 'playwright']);
     assert.ok(body.entries.every((e) => typeof e.risk.level === 'string'));
+    // The route must surface the per-entry risk level the UI badges on — Playwright
+    // is high-capability (browser automation + code-eval) and must read as 'high'.
+    assert.equal(body.entries.find((e) => e.id === 'playwright')!.risk.level, 'high');
   });
 
   test('install writes the server entry to .mcp.json (added=true), idempotent on re-install', () => {


### PR DESCRIPTION
## Playwright MCP → MCP Catalog (governed install)

Adds **Microsoft's Playwright MCP** (`@playwright/mcp`, `npx @playwright/mcp@latest`) to the `MCP_CATALOG` surface shipped in v5.4.2 (Context7 + Mermaid). Browser automation for agents — navigate, click, type, fill forms, inspect/mock network, take snapshots.

### The governance payoff
Unlike the read-only Context7/Mermaid entries (`low` risk), Playwright is a **high-capability** surface — its `browser_evaluate` tool runs arbitrary in-page JS, and Microsoft explicitly states *"Playwright MCP is **not** a security boundary."* The #108 risk scorer rates it **`high`** (the `broad-tool-names` high signal fires on `browser_evaluate`), so the catalog surfaces a **high-risk badge** and the install note carries the no-security-boundary caveat + safe-flag guidance (`--isolated`/`--headless`; avoid `--no-sandbox`). That's the whole point of curating installs through FailSafe.

### Tests (per-feature, red→green)
- Updated the catalog **count / id-list / all-low** assertions that would otherwise break on the new entry — the **v5.4.0 stale-assertion lesson, caught at orient** (not at the tag).
- Playwright → `high` with the `broad-tool-names` signal + out-scores Context7.
- Its `.mcp.json` merge shape (`mcpServers.playwright`).
- Renderer test: the **high-risk badge** renders for a high-capability entry.

### Verified (not fabricated)
Package `@playwright/mcp` + tool names (`browser_evaluate`, `browser_file_upload`, `browser_network_requests`) confirmed against the upstream README (github.com/microsoft/playwright-mcp).

### Notes
- **No README/version change** — README reflects shipped v5.4.2; Playwright ships in the next release.
- This PR runs the **new full `test:all` gate** (mocha + Playwright + native rebuild) — the catalog logic + renderer + the updated assertions all execute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)