### PR TITLE
feat(integrations): Agent Governance Toolkit installer on the Integrations tab (B-INT-16)

### DIFF
--- a/FailSafe/extension/src/extension/bootstrapServers.ts
+++ b/FailSafe/extension/src/extension/bootstrapServers.ts
@@ -98,6 +98,14 @@ export async function bootstrapServers(
   );
   consoleServer.setIdeTracker(ideTracker);
   consoleServer.setSystemRegistry(deps.systemRegistry);
+  // B-INT-16: integrated-terminal runner for the AGT installer. sendText with
+  // addNewLine=false pre-fills the command but does NOT execute it — the
+  // operator reviews and presses enter (no silent install).
+  consoleServer.setAgtRunInTerminal((name, command) => {
+    const terminal = vscode.window.createTerminal(name);
+    terminal.sendText(command, false);
+    terminal.show();
+  });
   wireBicameralIntegration(context, consoleServer, deps.workspaceRoot, {
     l3Service: {
       queueL3Approval: (req) => deps.qorelogicManager.queueL3Approval(req),

--- a/FailSafe/extension/src/integrations/agt/agt-catalog.ts
+++ b/FailSafe/extension/src/integrations/agt/agt-catalog.ts
@@ -1,0 +1,125 @@
+/**
+ * agt-catalog — curated, governed catalog of Microsoft Agent Governance Toolkit
+ * (AGT) installers (B-INT-16). AGT ships per-environment governance MODULES (not
+ * one package): language SDKs (Python/TypeScript/.NET/Rust/Go) + agent-host
+ * plugins (Claude Code / Copilot CLI / OpenCode / Antigravity CLI). The value
+ * here is auto-detecting the workspace environment and serving the matching,
+ * VERIFIED installer rather than a flat list the operator must triage.
+ *
+ * Install commands are verified against the upstream repo + live registries
+ * (microsoft/agent-governance-toolkit, 2026-06-03), NOT fabricated:
+ *  - Rust crate is `agentmesh` (4.0.0) — NOT `agent-governance` (the repo README
+ *    is stale at 3.2.2 there); we ship the correct crate.
+ *  - Go has no tagged release (proxy pseudo-version only) → status source-only.
+ *  - Claude Code installs via slash commands INSIDE Claude Code, not a shell —
+ *    so it is copy-only (runnable=false); the rest run in a terminal.
+ *  - AGT is Public Preview upstream; surfaced in the module note.
+ *
+ * Pure — no fs/vscode/network — so the catalog + environment detection are
+ * unit-tested deterministically.
+ */
+
+export type AgtModuleKind = 'language' | 'agent-host';
+
+export interface AgtModule {
+  id: string;
+  label: string;
+  /** Human environment label, e.g. "TypeScript / Node 18+". */
+  env: string;
+  kind: AgtModuleKind;
+  /**
+   * Workspace-root markers that imply this language module. Exact filenames
+   * (e.g. `go.mod`) or extension suffixes (e.g. `.csproj`). Language modules
+   * only; agent-host modules are not language-detected.
+   */
+  detect?: string[];
+  /** The verified install command. For runnable modules it is a shell command. */
+  command: string;
+  registry: string;
+  /** true → a shell command we can run in an integrated terminal; false → copy-only (e.g. Claude Code slash commands). */
+  runnable: boolean;
+  status: 'published' | 'source-only';
+  note: string;
+}
+
+export const AGT_MODULES: AgtModule[] = [
+  // ---- Language SDKs (auto-detected from workspace manifests) ----
+  {
+    id: 'typescript', label: 'TypeScript', env: 'TypeScript / Node 18+', kind: 'language',
+    detect: ['package.json', 'tsconfig.json'],
+    command: 'npm install @microsoft/agent-governance-sdk', registry: 'npm', runnable: true, status: 'published',
+    note: 'TypeScript SDK: agent identity, trust scoring, policy evaluation, audit logging.',
+  },
+  {
+    id: 'python', label: 'Python', env: 'Python 3.10+', kind: 'language',
+    detect: ['pyproject.toml', 'requirements.txt', 'setup.py', 'Pipfile'],
+    command: 'pip install agent-governance-toolkit[full]', registry: 'PyPI', runnable: true, status: 'published',
+    note: 'Full governance stack: policy engine, identity, sandboxing, audit, SRE.',
+  },
+  {
+    id: 'dotnet', label: '.NET', env: '.NET 8+', kind: 'language',
+    detect: ['.csproj', '.sln', '.fsproj'],
+    command: 'dotnet add package Microsoft.AgentGovernance', registry: 'NuGet', runnable: true, status: 'published',
+    note: '.NET governance kernel: policy eval, identity, MCP/Agents extensions.',
+  },
+  {
+    id: 'rust', label: 'Rust', env: 'Rust 1.70+', kind: 'language',
+    detect: ['Cargo.toml'],
+    command: 'cargo add agentmesh', registry: 'crates.io', runnable: true, status: 'published',
+    note: 'Rust governance crate (policy, trust, audit, identity). Crate is `agentmesh` (4.0.0); `agentmesh-mcp` is the standalone MCP crate.',
+  },
+  {
+    id: 'golang', label: 'Go', env: 'Go 1.25+', kind: 'language',
+    detect: ['go.mod'],
+    command: 'go get github.com/microsoft/agent-governance-toolkit/agent-governance-golang', registry: 'Go modules', runnable: true, status: 'source-only',
+    note: 'Go governance SDK. No tagged release upstream yet — `go get` pulls an untagged pseudo-version (snapshot), not a stable semver.',
+  },
+  // ---- Agent-host plugins/installers ----
+  {
+    id: 'copilot-cli', label: 'Copilot CLI', env: 'GitHub Copilot CLI', kind: 'agent-host',
+    command: 'npx @microsoft/agent-governance-copilot-cli install', registry: 'npm', runnable: true, status: 'published',
+    note: 'Deploys an AGT governance extension into the Copilot CLI home.',
+  },
+  {
+    id: 'opencode', label: 'OpenCode', env: 'OpenCode', kind: 'agent-host',
+    command: 'npm install @microsoft/agent-governance-opencode', registry: 'npm', runnable: true, status: 'published',
+    note: 'OpenCode governance plugin + bundled MCP server. After install, register it as a plugin in opencode.json.',
+  },
+  {
+    id: 'antigravity-cli', label: 'Antigravity CLI', env: 'Antigravity CLI', kind: 'agent-host',
+    command: 'npm install -g @microsoft/agent-governance-antigravity-cli && agt-antigravity install', registry: 'npm', runnable: true, status: 'published',
+    note: 'Two-step: global install, then `agt-antigravity install` deploys the governance extension into ~/.antigravity/extensions.',
+  },
+  {
+    id: 'claude-code', label: 'Claude Code', env: 'Claude Code', kind: 'agent-host',
+    command: '/plugin marketplace add microsoft/agent-governance-toolkit\n/plugin install agt-governance@agent-governance-toolkit', registry: 'Claude plugin marketplace', runnable: false, status: 'published',
+    note: 'Run these slash commands INSIDE Claude Code (not a terminal). Installs the agt-governance plugin: SessionStart/UserPromptSubmit/PreToolUse hooks + bundled MCP tools.',
+  },
+];
+
+const PREVIEW_BANNER = 'Microsoft Agent Governance Toolkit is Public Preview — APIs may change before GA.';
+
+/** AGT-wide advisory shown once in the UI header. */
+export function agtPreviewNotice(): string { return PREVIEW_BANNER; }
+
+/**
+ * Pure environment detection: given the names of files at the workspace root,
+ * return the language module ids whose markers are present. Exact filenames
+ * match by equality; markers beginning with '.' match by suffix (extensions).
+ * Agent-host modules are never language-detected.
+ */
+export function detectEnvironment(rootEntries: string[]): string[] {
+  const names = new Set(rootEntries.map((n) => n.toLowerCase()));
+  const matched: string[] = [];
+  for (const m of AGT_MODULES) {
+    if (m.kind !== 'language' || !m.detect) continue;
+    const hit = m.detect.some((marker) => {
+      const mk = marker.toLowerCase();
+      return mk.startsWith('.')
+        ? rootEntries.some((n) => n.toLowerCase().endsWith(mk))
+        : names.has(mk);
+    });
+    if (hit) matched.push(m.id);
+  }
+  return matched;
+}

--- a/FailSafe/extension/src/roadmap/ConsoleServer.ts
+++ b/FailSafe/extension/src/roadmap/ConsoleServer.ts
@@ -109,6 +109,7 @@ export class ConsoleServer {
   private mcpInterceptor: import("../governance/interceptor").McpInterceptor | null = null;
   /** B-BIC-12: editor-open dep wired by bootstrapBicameral (vscode.open). */
   private bicameralOpenFileInEditor: ((filePath: string, startLine?: number) => Promise<void>) | null = null;
+  private agtRunInTerminal: ((name: string, command: string) => void) | null = null;
   private bicameralCommand = "bicameral-mcp";
   private bicameralAutoConnect = false;
   private bicameralAutoConnectWriter: (value: boolean) => Promise<void> = async () => {};
@@ -204,6 +205,12 @@ export class ConsoleServer {
    *  vscode.open; null in test fixtures (route 503s). */
   setBicameralOpenFileInEditor(fn: ((filePath: string, startLine?: number) => Promise<void>) | null): void { this.bicameralOpenFileInEditor = fn; }
   getBicameralOpenFileInEditor(): ((filePath: string, startLine?: number) => Promise<void>) | null { return this.bicameralOpenFileInEditor; }
+  /** B-INT-16: register the integrated-terminal runner so the agt-install route
+   *  can pre-fill a terminal with a verified AGT install command (operator
+   *  presses enter). Wired by bootstrapServers to vscode.window.createTerminal;
+   *  null in test fixtures (route 503s). */
+  setAgtRunInTerminal(fn: ((name: string, command: string) => void) | null): void { this.agtRunInTerminal = fn; }
+  getAgtRunInTerminal(): ((name: string, command: string) => void) | null { return this.agtRunInTerminal; }
   /** B-BIC-16: drift-to-L3 mediator slot. Set by bootstrapBicameral when
    *  l3Service + eventBus + logger deps are available. Null in test fixtures
    *  that don't wire the mediator. */
@@ -300,6 +307,7 @@ export class ConsoleServer {
       getOpenDesignClient: () => this.openDesignClient,
       getMcpInterceptor: () => this.mcpInterceptor,
       getBicameralOpenFileInEditor: () => this.bicameralOpenFileInEditor,
+      getAgtRunInTerminal: () => this.agtRunInTerminal,
       getDriftToL3Mediator: () => this.driftToL3Mediator,
       getUpstreamMonitor: () => this.upstreamMonitor,
       getBicameralCommand: () => this.bicameralCommand,

--- a/FailSafe/extension/src/roadmap/routes/AgtRoute.ts
+++ b/FailSafe/extension/src/roadmap/routes/AgtRoute.ts
@@ -1,0 +1,79 @@
+import { Request, Response } from 'express';
+import * as fs from 'fs';
+import { AGT_MODULES, detectEnvironment, agtPreviewNotice } from '../../integrations/agt/agt-catalog';
+
+/**
+ * AgtRoute — backs the Integrations-tab Agent Governance Toolkit surface (B-INT-16).
+ *
+ *   GET  /api/v1/agt/modules            → modules + detected workspace environment
+ *   POST /api/actions/agt-install { id } → run the verified install command in an
+ *                                          integrated terminal (pre-filled; the
+ *                                          operator presses enter — no silent run)
+ *
+ * The terminal bridge is an injected dep (`runInTerminal`) wired by the host to
+ * vscode.window.createTerminal(...).sendText(cmd, /*addNewLine*\/ false); 503
+ * when unwired. Copy-only modules (Claude Code slash commands) are 400 here —
+ * the UI copies them instead of running them.
+ */
+
+export interface AgtRouteDeps {
+  workspaceRoot: string;
+  /** Pre-fill an integrated terminal with `command` (NOT auto-executed). */
+  runInTerminal?: (name: string, command: string) => void;
+}
+
+function listRootEntries(workspaceRoot: string): string[] {
+  try {
+    return fs.readdirSync(workspaceRoot, { withFileTypes: true })
+      .filter((d) => d.isFile())
+      .map((d) => d.name);
+  } catch {
+    return [];
+  }
+}
+
+export const AgtRoute = {
+  modules(_req: Request, res: Response, deps: AgtRouteDeps): void {
+    const detected = detectEnvironment(listRootEntries(deps.workspaceRoot));
+    const detectedSet = new Set(detected);
+    res.json({
+      preview: agtPreviewNotice(),
+      detected,
+      modules: AGT_MODULES.map((m) => ({
+        id: m.id,
+        label: m.label,
+        env: m.env,
+        kind: m.kind,
+        command: m.command,
+        registry: m.registry,
+        runnable: m.runnable,
+        status: m.status,
+        note: m.note,
+        recommended: detectedSet.has(m.id),
+      })),
+    });
+  },
+
+  install(req: Request, res: Response, deps: AgtRouteDeps): void {
+    const id = (req.body && (req.body as { id?: string }).id) || '';
+    const mod = AGT_MODULES.find((m) => m.id === id);
+    if (!mod) {
+      res.status(404).json({ ok: false, error: `unknown AGT module id: ${id}` });
+      return;
+    }
+    if (!mod.runnable) {
+      res.status(400).json({ ok: false, error: `${mod.label} installs via slash commands inside the agent, not a terminal — copy the command instead.` });
+      return;
+    }
+    if (!deps.runInTerminal) {
+      res.status(503).json({ ok: false, error: 'runInTerminal not wired' });
+      return;
+    }
+    try {
+      deps.runInTerminal(`AGT: ${mod.label}`, mod.command);
+      res.json({ ok: true, id, ran: mod.command });
+    } catch (e) {
+      res.status(500).json({ ok: false, error: e instanceof Error ? e.message : String(e) });
+    }
+  },
+};

--- a/FailSafe/extension/src/roadmap/services/ConsoleRouteRegistrar.ts
+++ b/FailSafe/extension/src/roadmap/services/ConsoleRouteRegistrar.ts
@@ -11,6 +11,7 @@ import {
 } from "../routes";
 import { TrackerRoute, type TrackerRouteDeps } from "../routes/TrackerRoute";
 import { McpRoute } from "../routes/McpRoute";
+import { AgtRoute } from "../routes/AgtRoute";
 import type { RouteDeps } from "../routes";
 import type { ApiRouteDeps } from "../routes/types";
 import { ConfigurationProfile } from "../../genesis/ConfigurationProfile";
@@ -92,6 +93,9 @@ export interface ConsoleRouteHost {
   /** B-BIC-12: editor-open dep accessor; null when bootstrap didn't wire one.
    *  Optional on the host so older route-host fixtures stay valid. */
   getBicameralOpenFileInEditor?: () => ((filePath: string, startLine?: number) => Promise<void>) | null;
+  /** B-INT-16: integrated-terminal runner accessor for the agt-install route;
+   *  null when bootstrap didn't wire one. Optional so older fixtures stay valid. */
+  getAgtRunInTerminal?: () => ((name: string, command: string) => void) | null;
   /** B-BIC-16: drift-to-L3 mediator accessor; null when bootstrap didn't wire one. */
   getDriftToL3Mediator: () => import("../../integrations/bicameral/DriftToL3Mediator").DriftToL3Mediator | null;
   /** Phase 4: upstream monitor accessor; null when bootstrap didn't wire one. */
@@ -386,6 +390,21 @@ export class ConsoleRouteRegistrar {
     // MCP catalog surface (B-INT-13/14): list + governed install into .mcp.json.
     app.get("/api/v1/mcp/catalog", (req, res) => McpRoute.catalog(req, res));
     app.post("/api/actions/mcp-install", (req, res) => McpRoute.install(req, res, { workspaceRoot: this.host.workspaceRoot }));
+
+    // Agent Governance Toolkit surface (B-INT-16): env-detected installer. The
+    // modules route auto-detects the workspace language; the install route
+    // pre-fills an integrated terminal with the verified command (operator
+    // presses enter — no silent run). runInTerminal is resolved lazily because
+    // routes register before bootstrapServers wires the vscode dep.
+    app.get("/api/v1/agt/modules", (req, res) => AgtRoute.modules(req, res, { workspaceRoot: this.host.workspaceRoot }));
+    app.post("/api/actions/agt-install", (req, res) => AgtRoute.install(req, res, {
+      workspaceRoot: this.host.workspaceRoot,
+      runInTerminal: (name, command) => {
+        const fn = this.host.getAgtRunInTerminal?.();
+        if (!fn) throw new Error("runInTerminal not wired");
+        fn(name, command);
+      },
+    }));
     this.registerConsoleExtras();
   }
 

--- a/FailSafe/extension/src/roadmap/ui/command-center.js
+++ b/FailSafe/extension/src/roadmap/ui/command-center.js
@@ -16,6 +16,7 @@ import { ReplayRenderer } from './modules/replay.js';
 import { BicameralRenderer } from './modules/bicameral-renderer.js';
 import { OpenDesignRenderer } from './modules/open-design-renderer.js';
 import { McpCatalogRenderer } from './modules/mcp-catalog-renderer.js';
+import { AgtRenderer } from './modules/agt-renderer.js';
 import { TabGroup } from './modules/tab-group.js';
 import { updateTickers, updateBootstrapBanner } from './modules/tickers.js';
 import { setWorkspaceRegistryClient, loadWorkspaceRegistry, initWorkspaceSelector } from './modules/workspace-registry.js';
@@ -47,6 +48,7 @@ document.addEventListener('DOMContentLoaded', () => {
       { key: 'bicameral',  label: 'Bicameral',   renderer: new BicameralRenderer('integrations', { client }) },
       { key: 'opendesign', label: 'Open Design', renderer: new OpenDesignRenderer('integrations') },
       { key: 'mcp',        label: 'MCP Catalog', renderer: new McpCatalogRenderer('integrations') },
+      { key: 'agt',        label: 'Agent Governance', renderer: new AgtRenderer('integrations') },
     ]),
     settings:   new SettingsRenderer('settings', { store }),
   };

--- a/FailSafe/extension/src/roadmap/ui/modules/agt-renderer.js
+++ b/FailSafe/extension/src/roadmap/ui/modules/agt-renderer.js
@@ -1,0 +1,148 @@
+/**
+ * AgtRenderer — Integrations-tab sub-view for the Microsoft Agent Governance
+ * Toolkit (AGT) installer (B-INT-16). Auto-detects the workspace language and
+ * surfaces the matching, verified install command first ("Recommended"), then
+ * the remaining language SDKs + agent-host plugins. Runnable modules get a
+ * "Run in terminal" button (pre-fills an integrated terminal — the operator
+ * presses enter; no silent install); copy-only modules (Claude Code slash
+ * commands) get a "Copy" button.
+ *
+ * Matches the console dark theme + the MCP catalog card layout. Visual surface
+ * verified in Chrome per feedback_design_reference_required.
+ */
+
+const STYLE_ID = 'cc-agt-style';
+const STYLE = `
+.cc-agt { display:flex; flex-direction:column; gap:12px; }
+.cc-agt h3 { margin:0 0 4px; font-size:1.05rem; }
+.cc-agt-sub { color:#9aa5b4; margin:0 0 4px; font-size:.9rem; }
+.cc-agt-preview { color:#f6ad55; font-size:.8rem; margin:0 0 6px; }
+.cc-agt-group { font-size:.78rem; text-transform:uppercase; letter-spacing:.04em; color:#7f8aa0; margin:6px 0 2px; }
+.cc-agt-card { background:linear-gradient(180deg,#141a22,#10161e); border:1px solid #202938; border-radius:10px; padding:14px; }
+.cc-agt-card.cc-agt-reco { border-color:#2f5e44; }
+.cc-agt-head { display:flex; align-items:center; gap:10px; margin-bottom:6px; flex-wrap:wrap; }
+.cc-agt-head strong { font-size:1rem; }
+.cc-agt-env { color:#9aa5b4; font-size:.82rem; }
+.cc-agt-badge { font-size:.7rem; padding:2px 8px; border-radius:999px; border:1px solid #273140; color:#9aa5b4; }
+.cc-agt-badge-reco { color:#68d391; border-color:#2f5e44; }
+.cc-agt-badge-src { color:#f6ad55; border-color:#6b4f2a; }
+.cc-agt-card p { color:#9aa5b4; margin:0 0 8px; font-size:.88rem; }
+.cc-agt-cmd { display:block; white-space:pre-wrap; font-family:ui-monospace,Consolas,monospace; font-size:.8rem; color:#f8e7a1;
+  background:#0b1118; border:1px solid #202938; border-radius:6px; padding:6px 8px; margin-bottom:10px; overflow-x:auto; }
+.cc-agt-actions { display:flex; align-items:center; gap:10px; }
+.cc-agt-btn { background:#141a22; color:#f1efe7; border:1px solid #2f5e44; border-radius:8px; padding:6px 14px; cursor:pointer; font:inherit; }
+.cc-agt-btn:hover { border-color:#68d391; }
+.cc-agt-btn-copy { border-color:#3a4658; }
+.cc-agt-btn-copy:hover { border-color:#6a7790; }
+.cc-agt-status { color:#9aa5b4; font-size:.82rem; }
+`;
+
+function esc(s) {
+  return String(s == null ? '' : s).replace(/[&<>"]/g, (c) => ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;' }[c]));
+}
+
+function card(m) {
+  const reco = m.recommended ? ' cc-agt-reco' : '';
+  const badges = [
+    m.recommended ? '<span class="cc-agt-badge cc-agt-badge-reco">recommended</span>' : '',
+    m.status === 'source-only' ? '<span class="cc-agt-badge cc-agt-badge-src">source-only (no release)</span>' : '',
+  ].join('');
+  const action = m.runnable
+    ? `<button class="cc-agt-btn cc-agt-run" data-id="${esc(m.id)}">Run in terminal</button>`
+    : `<button class="cc-agt-btn cc-agt-btn-copy cc-agt-copy" data-id="${esc(m.id)}">Copy command</button>`;
+  return `
+    <div class="cc-agt-card${reco}" data-id="${esc(m.id)}">
+      <div class="cc-agt-head"><strong>${esc(m.label)}</strong>
+        <span class="cc-agt-env">${esc(m.env)}</span>${badges}</div>
+      <p>${esc(m.note)}</p>
+      <code class="cc-agt-cmd">${esc(m.command)}</code>
+      <div class="cc-agt-actions">${action}<span class="cc-agt-status"></span></div>
+    </div>`;
+}
+
+export class AgtRenderer {
+  constructor(containerId) {
+    this.container = document.getElementById(containerId);
+  }
+
+  ensureStyle() {
+    if (document.getElementById(STYLE_ID)) return;
+    const el = document.createElement('style');
+    el.id = STYLE_ID;
+    el.textContent = STYLE;
+    document.head.appendChild(el);
+  }
+
+  async render() {
+    if (!this.container) return;
+    this.ensureStyle();
+    this.container.innerHTML = '<div class="cc-agt"><h3>Agent Governance Toolkit</h3><p class="cc-agt-sub">Loading…</p></div>';
+    let data;
+    try {
+      const res = await fetch('/api/v1/agt/modules');
+      data = await res.json();
+    } catch (err) {
+      this.container.innerHTML = `<div class="cc-agt"><h3>Agent Governance Toolkit</h3><p class="cc-agt-sub">Could not load AGT modules: ${esc(err)}</p></div>`;
+      return;
+    }
+    const modules = (data && data.modules) || [];
+    const detected = (data && data.detected) || [];
+    const reco = modules.filter((m) => m.recommended);
+    const langs = modules.filter((m) => m.kind === 'language' && !m.recommended);
+    const hosts = modules.filter((m) => m.kind === 'agent-host' && !m.recommended);
+    const detectLine = detected.length
+      ? `Detected ${detected.length === 1 ? 'environment' : 'environments'} in this workspace — the matching installer is recommended below.`
+      : 'No language manifest detected at the workspace root — pick the environment that matches your project or agent.';
+    const section = (title, list) => (list.length ? `<div class="cc-agt-group">${esc(title)}</div>${list.map(card).join('')}` : '');
+    this.container.innerHTML =
+      `<div class="cc-agt"><h3>Agent Governance Toolkit</h3>` +
+      `<p class="cc-agt-preview">${esc((data && data.preview) || '')}</p>` +
+      `<p class="cc-agt-sub">${esc(detectLine)} Commands are verified against the upstream registries; the install command is pre-filled into a terminal for you to review and run.</p>` +
+      section('Recommended for your workspace', reco) +
+      section('Language SDKs', langs) +
+      section('Agent hosts', hosts) +
+      (modules.length ? '' : '<p class="cc-agt-sub">No AGT modules available.</p>') +
+      `</div>`;
+    this.wire();
+  }
+
+  wire() {
+    this.container.querySelectorAll('.cc-agt-run').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const status = btn.closest('.cc-agt-card').querySelector('.cc-agt-status');
+        const id = btn.getAttribute('data-id');
+        btn.disabled = true;
+        if (status) status.textContent = 'Opening terminal…';
+        try {
+          const res = await fetch('/api/actions/agt-install', {
+            method: 'POST', headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id }),
+          });
+          const json = await res.json().catch(() => ({}));
+          if (status) status.textContent = res.ok ? 'Command pre-filled in the terminal — press enter to install.' : (json.error || `Error ${res.status}`);
+        } catch (err) {
+          if (status) status.textContent = String(err);
+        } finally {
+          btn.disabled = false;
+        }
+      });
+    });
+    this.container.querySelectorAll('.cc-agt-copy').forEach((btn) => {
+      btn.addEventListener('click', async () => {
+        const card = btn.closest('.cc-agt-card');
+        const status = card.querySelector('.cc-agt-status');
+        const cmd = card.querySelector('.cc-agt-cmd');
+        const text = cmd ? cmd.textContent : '';
+        try {
+          await navigator.clipboard.writeText(text);
+          if (status) status.textContent = 'Copied — run these inside the agent.';
+        } catch {
+          if (status) status.textContent = 'Copy failed — select the command above manually.';
+        }
+      });
+    });
+  }
+
+  // No WS event stream for the AGT installer — accept + ignore for TabGroup parity.
+  onEvent() {}
+}

--- a/FailSafe/extension/src/test/integrations/agt/agt-catalog.test.ts
+++ b/FailSafe/extension/src/test/integrations/agt/agt-catalog.test.ts
@@ -1,0 +1,44 @@
+import { strict as assert } from 'assert';
+import { AGT_MODULES, detectEnvironment, agtPreviewNotice } from '../../../integrations/agt/agt-catalog';
+
+suite('agt-catalog (B-INT-16)', () => {
+  test('catalog covers the 9 verified AGT environment modules', () => {
+    const ids = AGT_MODULES.map((m) => m.id).sort();
+    assert.deepEqual(ids, [
+      'antigravity-cli', 'claude-code', 'copilot-cli', 'dotnet', 'golang',
+      'opencode', 'python', 'rust', 'typescript',
+    ]);
+  });
+
+  test('install commands match the verified registries (corrected Rust crate + source-only Go + copy-only Claude Code)', () => {
+    const by = Object.fromEntries(AGT_MODULES.map((m) => [m.id, m]));
+    assert.equal(by['typescript'].command, 'npm install @microsoft/agent-governance-sdk');
+    assert.equal(by['python'].command, 'pip install agent-governance-toolkit[full]');
+    assert.equal(by['dotnet'].command, 'dotnet add package Microsoft.AgentGovernance');
+    // Rust crate is `agentmesh` (4.0.0) — NOT `agent-governance` (the upstream
+    // README is stale at 3.2.2 there). Guard against a regression to the wrong name.
+    assert.equal(by['rust'].command, 'cargo add agentmesh');
+    assert.equal(by['rust'].command.includes('agent-governance'), false);
+    // Go has no tagged release upstream → flagged source-only.
+    assert.equal(by['golang'].status, 'source-only');
+    // Claude Code installs via slash commands inside the agent → copy-only.
+    assert.equal(by['claude-code'].runnable, false);
+    assert.equal(by['copilot-cli'].runnable, true);
+    assert.equal(by['antigravity-cli'].runnable, true);
+  });
+
+  test('detectEnvironment maps workspace manifests to language modules (exact name + extension suffix)', () => {
+    assert.deepEqual(detectEnvironment(['package.json']), ['typescript']);
+    assert.deepEqual(detectEnvironment(['pyproject.toml']), ['python']);
+    assert.deepEqual(detectEnvironment(['go.mod']), ['golang']);
+    assert.deepEqual(detectEnvironment(['Cargo.toml']), ['rust']);
+    assert.deepEqual(detectEnvironment(['MyApp.csproj']), ['dotnet']); // suffix match
+    // No manifest → no recommendation; agent-host modules are never language-detected.
+    assert.deepEqual(detectEnvironment(['README.md', 'LICENSE']), []);
+    assert.deepEqual(detectEnvironment(['go.mod', 'Cargo.toml']).sort(), ['golang', 'rust']);
+  });
+
+  test('preview notice surfaces the AGT public-preview caveat', () => {
+    assert.match(agtPreviewNotice(), /Public Preview/i);
+  });
+});

--- a/FailSafe/extension/src/test/roadmap/agt-renderer.test.ts
+++ b/FailSafe/extension/src/test/roadmap/agt-renderer.test.ts
@@ -1,0 +1,73 @@
+// Structural (jsdom) tests for AgtRenderer (B-INT-16 UI).
+// NOTE: jsdom verifies STRUCTURE only — the visual surface still requires Chrome
+// verification per feedback_design_reference_required (not run here).
+
+import { strict as assert } from 'assert';
+import { JSDOM } from 'jsdom';
+// @ts-expect-error untyped JS module
+import { AgtRenderer } from '../../../src/roadmap/ui/modules/agt-renderer.js';
+
+const MODULES = {
+  preview: 'Microsoft Agent Governance Toolkit is Public Preview — APIs may change before GA.',
+  detected: ['typescript'],
+  modules: [
+    { id: 'typescript', label: 'TypeScript', env: 'TS', kind: 'language', command: 'npm install @microsoft/agent-governance-sdk', registry: 'npm', runnable: true, status: 'published', note: 'ts sdk', recommended: true },
+    { id: 'golang', label: 'Go', env: 'Go', kind: 'language', command: 'go get github.com/microsoft/agent-governance-toolkit/agent-governance-golang', registry: 'Go', runnable: true, status: 'source-only', note: 'go sdk', recommended: false },
+    { id: 'claude-code', label: 'Claude Code', env: 'Claude', kind: 'agent-host', command: '/plugin install agt-governance@agent-governance-toolkit', registry: 'plugin', runnable: false, status: 'published', note: 'cc plugin', recommended: false },
+  ],
+};
+
+interface G { window?: unknown; document?: unknown; fetch?: unknown }
+function setupDom(fetchImpl: (url: string, init?: unknown) => Promise<unknown>): { cleanup: () => void; doc: Document } {
+  const dom = new JSDOM('<!DOCTYPE html><html><head></head><body><div id="integrations"></div></body></html>', { url: 'http://localhost:9999' });
+  const g = global as unknown as G;
+  const prev = { window: g.window, document: g.document, fetch: g.fetch };
+  g.window = dom.window;
+  g.document = dom.window.document;
+  g.fetch = fetchImpl;
+  return {
+    doc: dom.window.document as unknown as Document,
+    cleanup: () => { g.window = prev.window; g.document = prev.document; g.fetch = prev.fetch; },
+  };
+}
+
+suite('AgtRenderer (B-INT-16, jsdom structural)', () => {
+  test('renders recommended-first, Run for runnable, Copy for copy-only, source-only badge', async () => {
+    const ctx = setupDom(async () => ({ ok: true, json: async () => MODULES }));
+    try {
+      await new AgtRenderer('integrations').render();
+      assert.equal(ctx.doc.querySelectorAll('.cc-agt-card').length, 3);
+      assert.equal(ctx.doc.querySelectorAll('.cc-agt-reco').length, 1, 'typescript is recommended');
+      // ts + go are runnable → Run buttons; claude-code is copy-only → Copy button.
+      assert.equal(ctx.doc.querySelectorAll('.cc-agt-run').length, 2);
+      assert.equal(ctx.doc.querySelectorAll('.cc-agt-copy').length, 1);
+      assert.ok(ctx.doc.querySelector('.cc-agt-badge-src'), 'Go source-only badge renders');
+      assert.ok(/Public Preview/.test(ctx.doc.body.innerHTML), 'preview caveat shown');
+    } finally { ctx.cleanup(); }
+  });
+
+  test('Run button POSTs agt-install with the module id', async () => {
+    const calls: string[] = [];
+    const ctx = setupDom(async (url: string) => {
+      calls.push(url);
+      if (url === '/api/v1/agt/modules') return { ok: true, json: async () => MODULES };
+      return { ok: true, json: async () => ({ ok: true }) };
+    });
+    try {
+      await new AgtRenderer('integrations').render();
+      const runBtn = ctx.doc.querySelector('.cc-agt-run') as HTMLButtonElement;
+      runBtn.click();
+      await new Promise((r) => setTimeout(r, 0));
+      assert.ok(calls.includes('/api/actions/agt-install'), 'POST on run click');
+    } finally { ctx.cleanup(); }
+  });
+
+  test('catalog fetch failure renders a non-empty error state (no throw)', async () => {
+    const ctx = setupDom(async () => { throw new Error('network down'); });
+    try {
+      await new AgtRenderer('integrations').render();
+      assert.ok(ctx.doc.querySelector('.cc-agt'));
+      assert.ok(/Could not load AGT modules/.test(ctx.doc.body.innerHTML));
+    } finally { ctx.cleanup(); }
+  });
+});

--- a/FailSafe/extension/src/test/roadmap/routes/AgtRoute.test.ts
+++ b/FailSafe/extension/src/test/roadmap/routes/AgtRoute.test.ts
@@ -1,0 +1,72 @@
+import { strict as assert } from 'assert';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { AgtRoute } from '../../../roadmap/routes/AgtRoute';
+
+function res() {
+  const r: { code: number; body: unknown; status: (c: number) => typeof r; json: (b: unknown) => void } = {
+    code: 200, body: undefined,
+    status(c: number) { r.code = c; return r; },
+    json(b: unknown) { r.body = b; },
+  };
+  return r;
+}
+function mkWs(): string { return fs.mkdtempSync(path.join(os.tmpdir(), 'failsafe-agt-')); }
+
+suite('AgtRoute (B-INT-16)', () => {
+  test('modules returns all 9 + detects the workspace environment (recommended flag)', () => {
+    const ws = mkWs();
+    fs.writeFileSync(path.join(ws, 'go.mod'), 'module example.com/x\n');
+    const r = res();
+    AgtRoute.modules({} as never, r as never, { workspaceRoot: ws });
+    const body = r.body as { modules: Array<{ id: string; recommended: boolean }>; detected: string[]; preview: string };
+    assert.equal(body.modules.length, 9);
+    assert.deepEqual(body.detected, ['golang']);
+    assert.equal(body.modules.find((m) => m.id === 'golang')!.recommended, true);
+    assert.equal(body.modules.find((m) => m.id === 'python')!.recommended, false);
+    assert.match(body.preview, /Public Preview/i);
+  });
+
+  test('modules tolerates an unreadable workspace (no detection, still lists modules)', () => {
+    const r = res();
+    AgtRoute.modules({} as never, r as never, { workspaceRoot: path.join(os.tmpdir(), 'failsafe-agt-does-not-exist-zzz') });
+    const body = r.body as { modules: unknown[]; detected: string[] };
+    assert.equal(body.modules.length, 9);
+    assert.deepEqual(body.detected, []);
+  });
+
+  test('install runs a runnable module command in the terminal via the injected dep', () => {
+    const calls: Array<[string, string]> = [];
+    const r = res();
+    AgtRoute.install({ body: { id: 'python' } } as never, r as never, {
+      workspaceRoot: '/tmp', runInTerminal: (n, c) => calls.push([n, c]),
+    });
+    assert.deepEqual(r.body, { ok: true, id: 'python', ran: 'pip install agent-governance-toolkit[full]' });
+    assert.equal(calls.length, 1);
+    assert.equal(calls[0][0], 'AGT: Python');
+    assert.equal(calls[0][1], 'pip install agent-governance-toolkit[full]');
+  });
+
+  test('install of a copy-only module (claude-code) → 400 and never touches the terminal', () => {
+    const calls: number[] = [];
+    const r = res();
+    AgtRoute.install({ body: { id: 'claude-code' } } as never, r as never, {
+      workspaceRoot: '/tmp', runInTerminal: () => calls.push(1),
+    });
+    assert.equal(r.code, 400);
+    assert.equal(calls.length, 0);
+  });
+
+  test('install with unknown id → 404', () => {
+    const r = res();
+    AgtRoute.install({ body: { id: 'nope' } } as never, r as never, { workspaceRoot: '/tmp' });
+    assert.equal(r.code, 404);
+  });
+
+  test('install when runInTerminal is unwired → 503', () => {
+    const r = res();
+    AgtRoute.install({ body: { id: 'python' } } as never, r as never, { workspaceRoot: '/tmp' });
+    assert.equal(r.code, 503);
+  });
+});

--- a/FailSafe/extension/src/test/ui/integrations-tab.spec.ts
+++ b/FailSafe/extension/src/test/ui/integrations-tab.spec.ts
@@ -66,17 +66,19 @@ test.skip("FX519 Bicameral card dims affordances for unsupported tools (deferred
 // for this UI change): three pills (Bicameral, Open Design, MCP Catalog),
 // Bicameral active by default, clicking the Open Design pill swaps to the Open
 // Design card and hides the Bicameral card.
-// (B-INT-13/14, v5.4.0 — MCP Catalog pill added as the third sub-view.)
+// (B-INT-13/14, v5.4.0 — MCP Catalog pill added as the third sub-view;
+//  B-INT-16 — Agent Governance pill added as the fourth.)
 test("B-INT-5 Integrations sub-tabs — pill switch swaps the visible integration", async ({ page }) => {
   controller = await serveConsoleServerUI({});
   await page.goto(`${controller.url}/command-center.html`);
   await page.locator('.tab-btn[data-target="integrations"]').click();
 
-  // Three integration pills render in the sub-view bar.
+  // Four integration pills render in the sub-view bar.
   const pills = page.locator('#integrations .cc-subview-bar .cc-pill');
-  await expect(pills).toHaveCount(3, { timeout: 10000 });
+  await expect(pills).toHaveCount(4, { timeout: 10000 });
   await expect(pills.nth(0)).toHaveText('Bicameral');
   await expect(pills.nth(1)).toHaveText('Open Design');
+  await expect(pills.nth(3)).toHaveText('Agent Governance');
   await expect(pills.nth(2)).toHaveText('MCP Catalog');
 
   // Bicameral is the default active sub-view.


### PR DESCRIPTION
## Agent Governance Toolkit → Integrations tab (auto-detect installer)

Surfaces Microsoft's **AGT** as a 4th Integrations sub-view that **auto-detects the workspace environment and serves the matching, verified installer** (your design). AGT ships per-environment governance **modules**, not one package — we list all 9 and recommend the detected match.

### What it does
- **Detects** the workspace language from manifests: `package.json`→TS, `pyproject.toml`/`requirements.txt`→Python, `go.mod`→Go, `Cargo.toml`→Rust, `*.csproj`→.NET — and marks the matching module **Recommended**.
- Lists the **language SDKs** + **agent-host plugins** (Claude Code, Copilot, OpenCode, Antigravity).
- **Run in integrated terminal**: the Run button pre-fills a terminal with the verified command (`createTerminal().sendText(cmd, false)`) — you review + press enter. **No silent install.** Claude Code is **copy-only** (its install is slash commands inside the agent, not a shell).

### Verified — not fabricated (research agent + live registries)
Caught two upstream-README errors: the Rust crate is **`agentmesh`** (4.0.0), **not** `agent-governance` (stale 3.2.2); and **Go** has no tagged release (source-only pseudo-version) — both handled correctly + flagged in the UI. AGT **Public Preview** caveat surfaced.

### Wiring + tests
- Mirrors the bicameral `openFileInEditor` dep pattern: `ConsoleServer.set/getAgtRunInTerminal` → registrar lazy closure → `bootstrapServers` `vscode` impl.
- Pure catalog + detection, the route (with a fake terminal dep → 503/400/404/200 paths), and the renderer (jsdom) are unit-tested.
- **The Integrations pill-count Playwright assertion is updated 3→4 proactively** — the v5.4.0 stale-assertion lesson, caught at design rather than the gate.
- Runs the full `test:all` PR gate.

### Scope
Installer-only this cycle (your call); `agent-failsafe` adapter modernization (consolidated `agent-governance-toolkit` + agent-sre) is the deferred follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)