### PR TITLE
feat(tracker): premium Development Tracker — full-history timeline, traceable records, tiered progress (B-INT-17)

### DIFF
--- a/FailSafe/extension/package.json
+++ b/FailSafe/extension/package.json
@@ -156,6 +156,10 @@
         "title": "FailSafe: Open Console (Browser Popout)"
       },
       {
+        "command": "failsafe.openDevelopmentTracker",
+        "title": "FailSafe: Open Development Tracker"
+      },
+      {
         "command": "failsafe.openRoadmap",
         "title": "FailSafe: Open Console (Browser)"
       },

--- a/FailSafe/extension/src/extension/commands.ts
+++ b/FailSafe/extension/src/extension/commands.ts
@@ -127,6 +127,27 @@ async function openRoadmapCompactEditor(): Promise<void> {
   }
 }
 
+async function openDevelopmentTracker(): Promise<void> {
+  const base = getBaseUrl().replace(/\/$/, "");
+  const target = `${base}/console/tracker`;
+  const ready = await waitForConsoleServerReady();
+  if (!ready) {
+    vscode.window.showWarningMessage(
+      "FailSafe Console is starting. Opening the Development Tracker now; refresh in a moment if needed.",
+    );
+  }
+  try {
+    const opened = await vscode.env.openExternal(vscode.Uri.parse(target));
+    if (!opened) {
+      throw new Error("openExternal returned false");
+    }
+  } catch {
+    vscode.window.showErrorMessage(
+      "Could not open the Development Tracker in browser. Check your system browser configuration.",
+    );
+  }
+}
+
 export function registerCommands(
   context: vscode.ExtensionContext,
   genesis: GenesisManager,
@@ -217,6 +238,9 @@ export function registerCommands(
   context.subscriptions.push(
     vscode.commands.registerCommand("failsafe.showDashboard", () => {
       return openRoadmapCompactEditor();
+    }),
+    vscode.commands.registerCommand("failsafe.openDevelopmentTracker", () => {
+      return openDevelopmentTracker();
     }),
   );
   context.subscriptions.push(

--- a/FailSafe/extension/src/roadmap/routes/TrackerRoute.ts
+++ b/FailSafe/extension/src/roadmap/routes/TrackerRoute.ts
@@ -1,29 +1,61 @@
 import { Request, Response } from 'express';
 import * as fs from 'fs';
 import * as path from 'path';
-import { TrackerGenerator } from '../tracker/TrackerGenerator';
+import { execFileSync } from 'child_process';
+import * as yaml from 'js-yaml';
+import { buildTrackerModel, validateManifest, discoverReleases, type TrackerManifest } from '../tracker/tracker-model';
 
 /**
  * TrackerRoute — serves the Development Tracker (standard:
  * docs/design/DEVELOPMENT_TRACKER_STANDARD.md).
  *
- *   GET /console/tracker  → the interactive HTML template
- *   GET /api/v1/tracker   → { model, lint, ok } generated fresh per request
+ *   GET /console/tracker  → the premium dashboard ENGINE (static HTML; fetches
+ *                            its data from /api/v1/tracker at runtime)
+ *   GET /api/v1/tracker   → { model, lint, ok } — the PLANNED manifest
+ *                            (docs/roadmap/programs.yaml) overlaid with the LIVE
+ *                            layer (shipped releases from git tags force prod)
  *
- * `render` reads the canonical template from docs/design/templates via
- * workspaceRoot (present at runtime regardless of the UI build/copy step), so
- * serving does not depend on uiDir resolution or copy-ui-js.
+ * The dashboard is data-driven: editing the tracker = editing the manifest, not
+ * markup. The engine is a single static file; this route only supplies data.
  */
 
 export interface TrackerRouteDeps {
   workspaceRoot: string;
   uiDir: string;
+  /** Program-progress retroactive windows (operator-configurable via VS Code
+   *  settings failsafe.tracker.{minor,patch}WindowDays). Default 60 / 30. */
+  minorWindowDays?: number;
+  patchWindowDays?: number;
 }
 
 const TEMPLATE_CANDIDATES = (deps: TrackerRouteDeps): string[] => [
-  path.join(deps.workspaceRoot, 'docs', 'design', 'templates', 'development-tracker.template.html'),
-  path.join(deps.uiDir, 'development-tracker.html'),
+  path.join(deps.uiDir, 'tracker', 'tracker-dashboard.html'),
+  // src fallback (Playwright/dev resolve uiDir to a src tree)
+  path.join(deps.uiDir, '..', '..', 'roadmap', 'ui', 'tracker', 'tracker-dashboard.html'),
+  path.join(deps.workspaceRoot, 'FailSafe', 'extension', 'src', 'roadmap', 'ui', 'tracker', 'tracker-dashboard.html'),
 ];
+
+const MANIFEST_PATH = (workspaceRoot: string): string =>
+  path.join(workspaceRoot, 'docs', 'roadmap', 'programs.yaml');
+
+/** Best-effort: the git tags present in the repo (corroborate shipped state). */
+function shippedReleaseIds(workspaceRoot: string): string[] {
+  try {
+    const out = execFileSync('git', ['tag'], { cwd: workspaceRoot, encoding: 'utf-8', timeout: 4000 });
+    return out.split('\n').map((t) => t.trim()).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+/** The repo's CHANGELOG is the complete release-history source (v0.1.0 → now). */
+function readChangelog(workspaceRoot: string): string {
+  try {
+    return fs.readFileSync(path.join(workspaceRoot, 'CHANGELOG.md'), 'utf-8');
+  } catch {
+    return '';
+  }
+}
 
 export const TrackerRoute = {
   render(_req: Request, res: Response, deps: TrackerRouteDeps): void {
@@ -31,20 +63,38 @@ export const TrackerRoute = {
       try { return fs.existsSync(f); } catch { return false; }
     });
     if (!file) {
-      res.status(503).send('Development Tracker template not found (docs/design/templates/development-tracker.template.html)');
+      res.status(503).send('Development Tracker dashboard not found (src/roadmap/ui/tracker/tracker-dashboard.html)');
       return;
     }
     res.type('html').send(fs.readFileSync(file, 'utf-8'));
   },
 
-  async api(_req: Request, res: Response, deps: TrackerRouteDeps): Promise<void> {
+  api(_req: Request, res: Response, deps: TrackerRouteDeps): void {
     try {
-      const gen = new TrackerGenerator({
-        workspaceRoot: deps.workspaceRoot,
-        now: () => new Date(),
+      const manifestPath = MANIFEST_PATH(deps.workspaceRoot);
+      if (!fs.existsSync(manifestPath)) {
+        res.status(503).json({ error: 'programs manifest not found at docs/roadmap/programs.yaml', model: null, lint: [], ok: false });
+        return;
+      }
+      const manifest = (yaml.load(fs.readFileSync(manifestPath, 'utf-8')) ?? {}) as TrackerManifest;
+      // Discover the complete release axis from the CHANGELOG (the governance
+      // files don't span the full history); the manifest only adds forecasts.
+      const discoveredReleases = discoverReleases(readChangelog(deps.workspaceRoot));
+      // Retroactive windows: deps override (future VS Code settings) → manifest
+      // progressWindows (user-editable today) → defaults 60 / 30.
+      const pw = manifest.progressWindows ?? {};
+      const model = buildTrackerModel(manifest, {
+        discoveredReleases,
+        shippedReleaseIds: shippedReleaseIds(deps.workspaceRoot),
+        now: new Date(),
+        minorDays: deps.minorWindowDays ?? pw.minorDays ?? 60,
+        patchDays: deps.patchWindowDays ?? pw.patchDays ?? 30,
       });
-      const { model, lint } = await gen.generate();
-      res.json({ model, lint, ok: !lint.some((f) => f.severity === 'abort') });
+      // Validate phases against the RESOLVED axis (discovered + manifest forecasts).
+      const lint = validateManifest(manifest, model.rcs.map((r) => r.id));
+      // The dashboard reads the data fields at the TOP LEVEL (data.rcs, data.meta,
+      // …), so spread the model out; lint/ok ride along for diagnostics.
+      res.json({ ...model, lint, ok: !lint.some((f) => f.severity === 'abort') });
     } catch (e) {
       res.status(500).json({ error: e instanceof Error ? e.message : String(e) });
     }

--- a/FailSafe/extension/src/roadmap/tracker/tracker-model.ts
+++ b/FailSafe/extension/src/roadmap/tracker/tracker-model.ts
@@ -1,0 +1,234 @@
+/**
+ * tracker-model — pure builder + validator for the Development Tracker data
+ * (the /api/v1/tracker payload the premium dashboard fetches).
+ *
+ * The manifest (docs/roadmap/programs.yaml) is the PLANNED layer: dynamic-N
+ * programs + weighted phases + verticals + the release axis. This module
+ * overlays the LIVE layer — which releases actually shipped (from META_LEDGER
+ * DELIVER + git tags) force their rc to `prod` — and validates the weighted
+ * model so the client-side cumulative() calculator is trustworthy.
+ *
+ * Pure (no fs/yaml/git/network) → deterministically unit-tested; the loader
+ * (TrackerRoute) does the I/O and calls buildTrackerModel.
+ */
+
+export type RcState = 'prod' | 'staging' | 'pr' | 'forecast';
+
+export interface TrackerRc {
+  id: string; state: RcState; tag?: string; note?: string;
+  /** Traceability link to where this release is documented (GitHub tag/release,
+   *  CHANGELOG). Governance doesn't expire — older releases stay traceable. */
+  ref?: string;
+  /** What shipped in this release (CHANGELOG entry summary) — makes every pip a
+   *  self-valuable record even where program-progress data is absent (Option A). */
+  summary?: string;
+  /** Whether weighted program-progress is populated for this release under the
+   *  tiered policy (majors: full history; minors: recent window; patches: recent
+   *  window). When false, the release shows only its traceable record. */
+  progressEligible?: boolean;
+}
+export interface TrackerProgram { key: string; name: string; accent: string }
+/** issue/pr resolve against the repo; `url` is an arbitrary link (Linear, docs,
+ *  a spec) so the specifics of older decisions are never a dead end. */
+export type TrackerPhaseLink =
+  | { t: 'issue' | 'pr'; n: number; label?: string }
+  | { t: 'url'; href: string; label?: string };
+export interface TrackerPhase {
+  prog: string; key: string; rc: string; w: number; title: string;
+  what?: string; benefit?: string;
+  breakdown?: Array<{ n: string; how?: string; val?: string }>;
+  links?: TrackerPhaseLink[];
+}
+export interface TrackerVertical {
+  key: string; name: string; accent: string; summary?: string;
+  functionality?: string[];
+  components?: Array<{ c: string; w: string; a: 'paid' | 'admin' | 'public' }>;
+  access?: Array<{ a: string; t: string }>;
+  backend?: string[]; background?: string;
+}
+export interface TrackerMeta {
+  eyebrow?: string; title?: string; titleEm?: string; sub?: string;
+  metaRow?: Array<{ label: string; value: string }>;
+  preamble?: string; footer?: string;
+}
+export interface TrackerManifest {
+  repo?: string;
+  meta?: TrackerMeta;
+  /** Operator-configurable retroactive windows for tiered program-progress
+   *  (minors within minorDays, patches within patchDays). Default 60 / 30. */
+  progressWindows?: { minorDays?: number; patchDays?: number };
+  rcs?: TrackerRc[];
+  programs?: TrackerProgram[];
+  phases?: TrackerPhase[];
+  verticals?: TrackerVertical[];
+  convergence?: unknown[];
+  promotion?: unknown[];
+  levers?: unknown[];
+}
+
+export type TrackerModel = TrackerManifest & { rcs: TrackerRc[]; programs: TrackerProgram[]; phases: TrackerPhase[]; verticals: TrackerVertical[] };
+
+export interface TrackerLintFinding { severity: 'warn' | 'abort'; code: string; detail: string }
+
+/** Numeric semver compare on `vX.Y.Z` ids (missing parts → 0). Ascending. */
+function cmpSemver(a: string, b: string): number {
+  const parse = (s: string) => s.replace(/^v/i, '').split('.').map((n) => parseInt(n, 10) || 0);
+  const [a1, a2, a3] = parse(a);
+  const [b1, b2, b3] = parse(b);
+  return a1 - b1 || a2 - b2 || a3 - b3;
+}
+
+/**
+ * Discover the COMPLETE release axis from the repo's CHANGELOG — the only
+ * artifact that spans the full history (META_LEDGER only covers recent cycles,
+ * git tags are incomplete, GitHub Releases are stale). Parses
+ * `## [X.Y.Z] - YYYY-MM-DD` headers → prod releases, ascending (oldest first),
+ * so the timeline is a complete picture from v0.1.0 to current.
+ */
+export function discoverReleases(changelogText: string): TrackerRc[] {
+  const lines = changelogText.split(/\r?\n/);
+  const headerRe = /^##\s*\[?(\d+\.\d+\.\d+)\]?\s*-\s*(\d{4}-\d{2}-\d{2})/;
+  const seen = new Set<string>();
+  const out: TrackerRc[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const m = headerRe.exec(lines[i]);
+    if (!m) continue;
+    const id = `v${m[1]}`;
+    if (seen.has(id)) continue;
+    seen.add(id);
+    // Summary = the first chunk of content under the header (Option A: what
+    // shipped), until the next release/section heading. Skips `### Added`-style
+    // sub-headers; normalizes bullets; capped so the pip stays readable.
+    const body: string[] = [];
+    for (let j = i + 1; j < lines.length && body.length < 8; j++) {
+      if (/^##\s/.test(lines[j])) break;          // next release/major section
+      const t = lines[j].trim();
+      if (!t) { if (body.length) break; else continue; } // first paragraph only
+      if (/^#{3,}\s/.test(t)) continue;            // skip "### Added" etc.
+      body.push(t.replace(/^[-*]\s*/, '• '));
+    }
+    const summary = body.join(' ').replace(/\s+/g, ' ').trim().slice(0, 300);
+    out.push({ id, state: 'prod', tag: 'released', note: m[2], summary: summary || undefined });
+  }
+  return out.sort((a, b) => cmpSemver(a.id, b.id));
+}
+
+/**
+ * Tiered program-progress eligibility: the weighted calculator is populated for
+ * MAJOR releases across the full history, but for MINOR/PATCH releases only
+ * within a recent window (so we don't owe weighted data for every old patch).
+ * Pure — `now` is injected. Non-prod (forecast) + undated + unparseable → shown.
+ */
+export function isProgramEligible(
+  rc: TrackerRc,
+  opts: { now: Date; minorDays: number; patchDays: number },
+): boolean {
+  const m = /^v?(\d+)\.(\d+)\.(\d+)/.exec(rc.id);
+  if (!m) return true;
+  const minor = parseInt(m[2], 10);
+  const patch = parseInt(m[3], 10);
+  if (rc.state !== 'prod') return true;          // forecast/planned → always tracked
+  if (minor === 0 && patch === 0) return true;   // major → full history
+  const date = rc.note ? new Date(rc.note) : null;
+  if (!date || Number.isNaN(date.getTime())) return true;
+  const ageDays = (opts.now.getTime() - date.getTime()) / 86_400_000;
+  return patch > 0 ? ageDays <= opts.patchDays : ageDays <= opts.minorDays;
+}
+
+/**
+ * Build the /api/v1/tracker model. The release axis is the DISCOVERED full
+ * history (CHANGELOG) when provided, plus any manifest-declared releases that
+ * aren't yet discovered (forecasts/future). Git-tagged ids force `prod`.
+ */
+export function buildTrackerModel(
+  manifest: TrackerManifest,
+  live: {
+    discoveredReleases?: TrackerRc[]; shippedReleaseIds?: string[];
+    now?: Date; minorDays?: number; patchDays?: number;
+  } = {},
+): TrackerModel {
+  const shipped = new Set((live.shippedReleaseIds ?? []).map((s) => s.trim()).filter(Boolean));
+  const discovered = live.discoveredReleases ?? [];
+  const discoveredIds = new Set(discovered.map((r) => r.id));
+
+  let rcs: TrackerRc[];
+  if (discovered.length) {
+    // Discovered full history (prod, ascending) + manifest releases not yet
+    // discovered (future/forecast), appended after the discovered tail.
+    const forecasts = (manifest.rcs ?? [])
+      .filter((rc) => !discoveredIds.has(rc.id))
+      .sort((a, b) => cmpSemver(a.id, b.id));
+    rcs = [...discovered, ...forecasts];
+  } else {
+    // No CHANGELOG available — fall back to the manifest's declared axis.
+    rcs = manifest.rcs ?? [];
+  }
+  rcs = rcs.map((rc) => (shipped.has(rc.id) && rc.state !== 'prod' ? { ...rc, state: 'prod' as RcState } : rc));
+
+  // Traceability: every shipped release links to its record so older decisions
+  // stay auditable (tagged → GitHub release/tag; changelog-only → CHANGELOG).
+  const repo = manifest.repo ?? '';
+  rcs = rcs.map((rc) => {
+    if (rc.ref || !repo) return rc;
+    if (shipped.has(rc.id)) return { ...rc, ref: `https://github.com/${repo}/releases/tag/${rc.id}` };
+    if (rc.state === 'prod') return { ...rc, ref: `https://github.com/${repo}/blob/main/CHANGELOG.md` };
+    return rc; // forecast: no ref unless the manifest declared one
+  });
+
+  // Tiered program-progress eligibility (majors always; minors/patches within
+  // their recent window). Computed only when `now` is supplied — the live route
+  // always supplies it; pure callers may omit, leaving progressEligible
+  // undefined (the dashboard treats undefined as eligible for back-compat).
+  if (live.now) {
+    const minorDays = live.minorDays ?? 60;
+    const patchDays = live.patchDays ?? 30;
+    const now = live.now;
+    rcs = rcs.map((rc) => ({ ...rc, progressEligible: isProgramEligible(rc, { now, minorDays, patchDays }) }));
+  }
+
+  return {
+    repo,
+    meta: manifest.meta ?? {},
+    rcs,
+    programs: manifest.programs ?? [],
+    phases: manifest.phases ?? [],
+    verticals: manifest.verticals ?? [],
+    ...(manifest.convergence ? { convergence: manifest.convergence } : {}),
+    ...(manifest.promotion ? { promotion: manifest.promotion } : {}),
+    ...(manifest.levers ? { levers: manifest.levers } : {}),
+  };
+}
+
+/**
+ * Validate the weighted model so the timeline calculator is sound. `abort`
+ * findings mean the data is structurally broken (dangling rc/prog refs);
+ * `warn` findings (weights not ~100) are surfaced but non-fatal.
+ */
+export function validateManifest(m: TrackerManifest, knownReleaseIds?: string[]): TrackerLintFinding[] {
+  const out: TrackerLintFinding[] = [];
+  // Phases may target discovered (CHANGELOG) releases not declared in the
+  // manifest — validate against the resolved axis when supplied.
+  const rcIds = new Set(knownReleaseIds ?? (m.rcs ?? []).map((r) => r.id));
+  const progKeys = new Set((m.programs ?? []).map((p) => p.key));
+
+  for (const ph of m.phases ?? []) {
+    if (!progKeys.has(ph.prog)) {
+      out.push({ severity: 'abort', code: 'phase-unknown-program', detail: `phase ${ph.key} → program '${ph.prog}' not in programs[]` });
+    }
+    if (!rcIds.has(ph.rc)) {
+      out.push({ severity: 'abort', code: 'phase-unknown-rc', detail: `phase ${ph.key} → release '${ph.rc}' not in rcs[]` });
+    }
+    if (typeof ph.w !== 'number' || ph.w < 0) {
+      out.push({ severity: 'abort', code: 'phase-bad-weight', detail: `phase ${ph.key} → weight must be a non-negative number` });
+    }
+  }
+
+  // Per-program weights should sum to ~100 so cumulative() reads as a percent.
+  for (const prog of m.programs ?? []) {
+    const sum = (m.phases ?? []).filter((p) => p.prog === prog.key).reduce((a, p) => a + (typeof p.w === 'number' ? p.w : 0), 0);
+    if (sum !== 100) {
+      out.push({ severity: 'warn', code: 'program-weight-sum', detail: `program '${prog.key}' phase weights sum to ${sum}, not 100` });
+    }
+  }
+  return out;
+}

--- a/FailSafe/extension/src/roadmap/ui/command-center.js
+++ b/FailSafe/extension/src/roadmap/ui/command-center.js
@@ -17,6 +17,7 @@ import { BicameralRenderer } from './modules/bicameral-renderer.js';
 import { OpenDesignRenderer } from './modules/open-design-renderer.js';
 import { McpCatalogRenderer } from './modules/mcp-catalog-renderer.js';
 import { TabGroup } from './modules/tab-group.js';
+import { TrackerEmbedRenderer } from './modules/tracker-embed-renderer.js';
 import { updateTickers, updateBootstrapBanner } from './modules/tickers.js';
 import { setWorkspaceRegistryClient, loadWorkspaceRegistry, initWorkspaceSelector } from './modules/workspace-registry.js';
 import { governanceSubviewForRoute, parseCommandCenterHash } from './modules/command-center-deeplink.js';
@@ -42,6 +43,7 @@ document.addEventListener('DOMContentLoaded', () => {
     workspace: new TabGroup('workspace', [
       { key: 'skills',     label: 'Skills',     renderer: new SkillsRenderer('workspace', { client }) },
       { key: 'brainstorm', label: 'Mindmap',    renderer: new BrainstormRenderer('workspace', { store, client }) },
+      { key: 'tracker',    label: 'Tracker',    renderer: new TrackerEmbedRenderer('workspace') },
     ]),
     integrations: new TabGroup('integrations', [
       { key: 'bicameral',  label: 'Bicameral',   renderer: new BicameralRenderer('integrations', { client }) },

--- a/FailSafe/extension/src/roadmap/ui/modules/tracker-embed-renderer.js
+++ b/FailSafe/extension/src/roadmap/ui/modules/tracker-embed-renderer.js
@@ -1,0 +1,76 @@
+/**
+ * TrackerEmbedRenderer — Workspace-tab sub-view that embeds the Development
+ * Tracker dashboard inline (via an iframe to /console/tracker, which isolates
+ * the dashboard's own fonts/aurora/styles from the console shell) plus a
+ * "Pop out ↗" affordance that opens the full dashboard in a new browser tab.
+ *
+ * The dashboard itself is the premium single-file engine served at
+ * /console/tracker; this renderer is just the in-Workspace mount + pop-out.
+ */
+
+const STYLE_ID = 'cc-tracker-embed-style';
+const STYLE = `
+.cc-trk { display:flex; flex-direction:column; gap:10px; height:100%; min-height:600px; }
+.cc-trk-bar { display:flex; align-items:center; justify-content:space-between; gap:10px; }
+.cc-trk-bar h3 { margin:0; font-size:1.02rem; }
+.cc-trk-bar .cc-trk-sub { color:#9aa5b4; font-size:.84rem; }
+.cc-trk-popout { background:#141a22; color:#f1efe7; border:1px solid #3a4658; border-radius:8px;
+  padding:5px 12px; cursor:pointer; font:inherit; font-size:.85rem; text-decoration:none; white-space:nowrap; }
+.cc-trk-popout:hover { border-color:#68d391; }
+.cc-trk-frame { flex:1; width:100%; min-height:600px; border:1px solid #202938; border-radius:10px; background:#0c0f14; }
+`;
+
+export class TrackerEmbedRenderer {
+  constructor(containerId) {
+    this.container = document.getElementById(containerId);
+  }
+
+  ensureStyle() {
+    if (document.getElementById(STYLE_ID)) return;
+    const el = document.createElement('style');
+    el.id = STYLE_ID;
+    el.textContent = STYLE;
+    document.head.appendChild(el);
+  }
+
+  render() {
+    if (!this.container) return;
+    this.ensureStyle();
+    const url = '/console/tracker';
+    const wrap = document.createElement('div');
+    wrap.className = 'cc-trk';
+
+    const bar = document.createElement('div');
+    bar.className = 'cc-trk-bar';
+    const heading = document.createElement('div');
+    const h3 = document.createElement('h3');
+    h3.textContent = 'Development Tracker';
+    const sub = document.createElement('span');
+    sub.className = 'cc-trk-sub';
+    sub.textContent = ' release timeline + program progress, generated from the repo';
+    heading.appendChild(h3);
+    heading.appendChild(sub);
+    const popout = document.createElement('a');
+    popout.className = 'cc-trk-popout';
+    popout.href = url;
+    popout.target = '_blank';
+    popout.rel = 'noopener noreferrer';
+    popout.textContent = 'Pop out ↗';
+    bar.appendChild(heading);
+    bar.appendChild(popout);
+
+    const frame = document.createElement('iframe');
+    frame.className = 'cc-trk-frame';
+    frame.src = url;
+    frame.title = 'Development Tracker';
+    frame.setAttribute('loading', 'lazy');
+
+    wrap.appendChild(bar);
+    wrap.appendChild(frame);
+    this.container.innerHTML = '';
+    this.container.appendChild(wrap);
+  }
+
+  // No WS event stream for the embedded tracker — accept + ignore for TabGroup parity.
+  onEvent() {}
+}

--- a/FailSafe/extension/src/roadmap/ui/tracker/tracker-dashboard.html
+++ b/FailSafe/extension/src/roadmap/ui/tracker/tracker-dashboard.html
@@ -1,0 +1,2125 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8" />
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>Status Tracker</title>
+<link rel="preconnect" href="https://fonts.googleapis.com" />
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+<link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;1,9..144,400;1,9..144,500&family=Hanken+Grotesk:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+<style>
+/* ============================================================
+   TOKENS — premium 4-step surface ramp + 3-step text ramp
+   ============================================================ */
+:root{
+  --ink:#0c0f14;
+  --ink-2:#12161e;
+  --panel:#161b24;
+  --panel-2:#1c222d;
+  --line:#2a313d;
+  --line-soft:#232a35;
+  --text:#ece9e1;
+  --text-dim:#97a0ad;
+  --text-faint:#5f6875;
+  --good:#5fd49a;
+  --warn:#e7b04b;
+  --radius:14px;
+  --shadow:0 18px 50px -20px rgba(0,0,0,.7);
+  --serif:'Fraunces', Georgia, 'Times New Roman', serif;
+  --sans:'Hanken Grotesk', system-ui, -apple-system, 'Segoe UI', Roboto, sans-serif;
+  --mono:'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+  --accent:var(--good); /* default; overridden per program/vertical via --accent */
+}
+
+*{box-sizing:border-box}
+html,body{margin:0;padding:0}
+body{
+  font-family:var(--sans);
+  color:var(--text);
+  background:var(--ink);
+  font-variant-numeric:tabular-nums;
+  line-height:1.55;
+  -webkit-font-smoothing:antialiased;
+  position:relative;
+  min-height:100vh;
+}
+
+/* Canvas — three stacked fixed radial gradients over --ink, fixed attachment */
+body{
+  background-color:var(--ink);
+  background-image:
+    radial-gradient(60% 45% at 88% 4%,  rgba(64,196,196,.09), transparent 60%),
+    radial-gradient(55% 45% at 6% 2%,   rgba(231,110,168,.08), transparent 60%),
+    radial-gradient(70% 50% at 50% 102%,rgba(231,176,75,.07),  transparent 60%);
+  background-attachment:fixed;
+  background-repeat:no-repeat;
+}
+/* Film-grain overlay — inline SVG feTurbulence fractal noise data-URI */
+body::before{
+  content:"";
+  position:fixed;
+  inset:0;
+  z-index:0;
+  pointer-events:none;
+  opacity:.035;
+  background-image:url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='160' height='160'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)'/%3E%3C/svg%3E");
+  background-repeat:repeat;
+}
+
+/* All real content sits above the grain */
+.skip-link,.wrap{position:relative;z-index:1}
+
+/* ============================================================
+   SKIP LINK
+   ============================================================ */
+.skip-link{
+  position:absolute;
+  left:12px;top:-60px;
+  background:var(--panel);
+  color:var(--text);
+  border:1px solid var(--line);
+  border-radius:8px;
+  padding:8px 14px;
+  font-family:var(--mono);
+  font-size:12px;
+  text-decoration:none;
+  transition:top .18s ease;
+}
+.skip-link:focus{top:12px;outline:2px solid var(--good)}
+
+/* ============================================================
+   WRAP / HEADER
+   ============================================================ */
+.wrap{
+  max-width:1180px;
+  margin:0 auto;
+  padding:clamp(24px,5vw,64px) clamp(18px,4vw,44px) 80px;
+}
+
+.masthead{margin-bottom:56px}
+.eyebrow{
+  display:inline-flex;
+  align-items:center;
+  gap:9px;
+  font-family:var(--mono);
+  font-size:12px;
+  letter-spacing:.16em;
+  text-transform:uppercase;
+  color:var(--text-dim);
+  margin:0 0 18px;
+}
+.eyebrow .dot{
+  width:8px;height:8px;border-radius:50%;
+  background:var(--good);
+  box-shadow:0 0 0 0 rgba(95,212,154,.55);
+  animation:pulse 2.4s ease-out infinite;
+}
+@keyframes pulse{
+  0%{box-shadow:0 0 0 0 rgba(95,212,154,.5)}
+  70%{box-shadow:0 0 0 9px rgba(95,212,154,0)}
+  100%{box-shadow:0 0 0 0 rgba(95,212,154,0)}
+}
+h1.title{
+  font-family:var(--serif);
+  font-weight:400;
+  font-size:clamp(2.1rem,6vw,3.6rem);
+  line-height:1.04;
+  letter-spacing:-.01em;
+  margin:0 0 18px;
+}
+h1.title em{
+  font-style:italic;
+  font-weight:500;
+  color:var(--warn);
+}
+.sub{
+  color:var(--text-dim);
+  max-width:62ch;
+  font-size:1.02rem;
+  margin:0 0 22px;
+}
+.meta-row{
+  display:flex;
+  flex-wrap:wrap;
+  gap:10px 26px;
+  font-family:var(--mono);
+  font-size:12px;
+  color:var(--text-faint);
+}
+.meta-row .m-item{display:inline-flex;gap:7px;align-items:baseline}
+.meta-row .m-label{color:var(--text-faint);text-transform:uppercase;letter-spacing:.08em}
+.meta-row .m-value{color:var(--text-dim)}
+
+/* ============================================================
+   SECTIONS
+   ============================================================ */
+section.sec{margin-bottom:52px}
+section.sec > h2{
+  font-family:var(--serif);
+  font-weight:400;
+  font-size:clamp(1.4rem,3.2vw,1.9rem);
+  letter-spacing:-.01em;
+  margin:0 0 6px;
+  display:flex;
+  align-items:baseline;
+  gap:14px;
+}
+section.sec > h2 .idx{
+  font-family:var(--mono);
+  font-size:.72rem;
+  color:var(--text-faint);
+  letter-spacing:.1em;
+  border:1px solid var(--line-soft);
+  border-radius:6px;
+  padding:3px 7px;
+  transform:translateY(-3px);
+}
+.section-sub{
+  color:var(--text-dim);
+  max-width:64ch;
+  font-size:.96rem;
+  margin:0 0 22px;
+}
+
+/* ============================================================
+   1 · METHODOLOGY PREAMBLE
+   ============================================================ */
+.preamble{
+  border:1px solid var(--line-soft);
+  border-left:3px solid var(--good);
+  background:linear-gradient(165deg,var(--panel),var(--ink-2));
+  border-radius:var(--radius);
+  padding:22px 26px 22px 24px;
+  box-shadow:var(--shadow);
+  display:grid;
+  grid-template-columns:auto 1fr;
+  gap:18px;
+  align-items:start;
+}
+.preamble .glyph{
+  font-family:var(--serif);
+  font-size:2.4rem;
+  line-height:1;
+  color:var(--good);
+  font-style:italic;
+}
+.preamble p{margin:0;color:var(--text-dim)}
+.preamble code{
+  font-family:var(--mono);
+  font-size:.85em;
+  background:var(--ink);
+  border:1px solid var(--line-soft);
+  border-radius:5px;
+  padding:1px 6px;
+  color:var(--text);
+}
+
+/* ============================================================
+   2 · §01 RELEASE TIMELINE
+   ============================================================ */
+.timeline-wrap{position:relative}
+.timeline{
+  position:relative;
+  display:flex;
+  gap:0;
+  overflow-x:auto;
+  padding:28px 6px 14px;
+  scrollbar-width:thin;
+}
+.timeline::before{
+  content:"";
+  position:absolute;
+  left:34px;right:34px;
+  top:calc(28px + 30px); /* aligns roughly to pip center */
+  height:2px;
+  background:linear-gradient(90deg,
+     var(--line) 0%, var(--line) 62%,
+     transparent 62%);
+  background-image:
+     linear-gradient(90deg,var(--line) 62%, transparent 62%),
+     repeating-linear-gradient(90deg,var(--text-faint) 0 6px,transparent 6px 12px);
+  background-size:100% 2px, 100% 2px;
+  background-position:0 0, 62% 0;
+  background-repeat:no-repeat;
+  z-index:0;
+}
+/* Solid up to ~62%, dashed after to mark shipped→forecast */
+.timeline .rail-solid{position:absolute;left:34px;top:calc(28px + 29px);height:2px;width:calc((100% - 68px)*.62);background:linear-gradient(90deg,var(--good),var(--text-dim));z-index:0;border-radius:2px}
+.timeline .rail-dash{position:absolute;right:34px;top:calc(28px + 29px);height:2px;width:calc((100% - 68px)*.38);background-image:repeating-linear-gradient(90deg,var(--text-faint) 0 5px,transparent 5px 11px);z-index:0}
+
+.tl-node{
+  position:relative;
+  z-index:1;
+  flex:0 0 auto;
+  min-width:96px;
+  display:flex;
+  flex-direction:column;
+  align-items:center;
+  gap:9px;
+  background:transparent;
+  border:0;
+  cursor:pointer;
+  color:inherit;
+  padding:4px 8px;
+  border-radius:10px;
+}
+.tl-node:focus-visible{outline:2px solid var(--good);outline-offset:2px}
+.tl-node .rc-label{
+  font-family:var(--mono);
+  font-size:12px;
+  color:var(--text-dim);
+  letter-spacing:.04em;
+}
+.tl-node .pip{
+  width:18px;height:18px;border-radius:50%;
+  transition:transform .22s cubic-bezier(.22,.61,.36,1), box-shadow .22s ease;
+  background:var(--panel);
+}
+.tl-node .rc-tag{
+  font-family:var(--mono);
+  font-size:9px;
+  text-transform:uppercase;
+  letter-spacing:.12em;
+  color:var(--text-faint);
+}
+/* pip states */
+.pip.s-prod{background:#fff;border:1px solid #fff}
+.pip.s-staging{background:var(--good);border:1px solid var(--good)}
+.pip.s-pr{background:var(--ink);border:2px dotted var(--text-dim)}
+.pip.s-forecast{background:transparent;border:2px dashed var(--text-faint)}
+.tl-node:hover .pip{transform:scale(1.25)}
+.tl-node[aria-pressed="true"] .pip{
+  transform:scale(1.45);
+  box-shadow:0 0 0 4px rgba(255,255,255,.18), 0 0 14px rgba(255,255,255,.25);
+}
+.tl-node[aria-pressed="true"] .rc-label{color:var(--text)}
+
+.tl-readout{
+  font-family:var(--mono);
+  font-size:12.5px;
+  color:var(--text-dim);
+  margin:14px 2px 6px;
+  padding:10px 14px;
+  border:1px solid var(--line-soft);
+  border-radius:10px;
+  background:var(--ink-2);
+  line-height:1.7;
+}
+.tl-readout strong{color:var(--text)}
+.tl-legend{
+  display:flex;flex-wrap:wrap;gap:8px 20px;
+  font-family:var(--mono);font-size:11px;color:var(--text-faint);
+  margin-top:8px;
+}
+.tl-legend span{display:inline-flex;align-items:center;gap:7px}
+.tl-legend .sw{width:12px;height:12px;border-radius:50%}
+.tl-legend .sw.s-prod{background:#fff}
+.tl-legend .sw.s-staging{background:var(--good)}
+.tl-legend .sw.s-pr{background:var(--ink);border:2px dotted var(--text-dim)}
+.tl-legend .sw.s-forecast{background:transparent;border:2px dashed var(--text-faint)}
+
+/* ── Timeline zoom: breadcrumb + indicators ── */
+.tl-breadcrumb{
+  display:flex;align-items:center;flex-wrap:wrap;gap:8px 10px;
+  font-family:var(--mono);font-size:11.5px;color:var(--text-faint);
+  margin:0 2px 14px;
+}
+.crumb{
+  font-family:var(--mono);font-size:11.5px;color:var(--text-dim);
+  background:transparent;border:1px solid var(--line-soft);border-radius:8px;
+  padding:3px 9px;cursor:pointer;
+  transition:border-color .2s ease, color .2s ease;
+}
+.crumb:hover{border-color:var(--good);color:var(--text)}
+.crumb:focus-visible{outline:2px solid var(--good);outline-offset:2px}
+.crumb.here{color:var(--text);border-color:var(--line);cursor:default}
+.crumb[aria-disabled="true"]{cursor:default;opacity:.85}
+.crumb-sep{color:var(--text-faint)}
+.zoom-ind{
+  font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.1em;
+  color:var(--text-faint);border:1px solid var(--line-soft);border-radius:999px;
+  padding:2px 9px;
+}
+.crumb-zoomout{
+  margin-left:auto;
+  font-family:var(--mono);font-size:11px;color:var(--good);
+  background:transparent;border:1px solid var(--good);border-radius:999px;
+  padding:3px 11px;cursor:pointer;
+}
+.crumb-zoomout:hover{background:var(--panel)}
+.crumb-zoomout:focus-visible{outline:2px solid var(--good);outline-offset:2px}
+
+/* major sub-label (representative id / release count under a collapsed anchor) */
+.tl-node .rc-sub{
+  font-family:var(--mono);font-size:9px;
+  color:var(--text-faint);letter-spacing:.04em;
+  max-width:108px;text-align:center;line-height:1.3;
+}
+.tl-node[data-major="1"] .pip{box-shadow:0 0 0 3px rgba(151,160,173,.14)}
+.tl-node[data-major="1"][aria-pressed="true"] .pip{box-shadow:0 0 0 4px rgba(255,255,255,.18), 0 0 14px rgba(255,255,255,.25)}
+
+/* readout: ref traceability link + major context */
+.tl-readout .ro-ref{
+  font-family:var(--mono);font-size:11.5px;color:var(--good);text-decoration:none;
+  border:1px solid var(--line-soft);border-radius:7px;padding:2px 8px;margin-left:6px;
+  display:inline-flex;align-items:center;gap:5px;white-space:nowrap;
+}
+.tl-readout .ro-ref:hover{border-color:var(--good);color:var(--text)}
+.tl-readout .ro-ref:focus-visible{outline:2px solid var(--good);outline-offset:2px}
+.tl-readout .ro-major{color:var(--text-faint)}
+
+/* ── Release record — every pip is self-valuable (governance doesn't expire) ── */
+.release-record{
+  border:1px solid var(--line-soft);
+  border-left:3px solid var(--good);
+  background:linear-gradient(165deg,var(--panel),var(--ink-2));
+  border-radius:var(--radius);
+  padding:14px 18px;
+  margin:12px 2px 6px;
+  box-shadow:var(--shadow);
+  display:grid;
+  grid-template-columns:auto 1fr auto;
+  gap:6px 16px;
+  align-items:baseline;
+}
+.release-record .rr-id{
+  font-family:var(--mono);
+  font-size:13px;
+  font-weight:600;
+  color:var(--text);
+  letter-spacing:.02em;
+}
+.release-record .rr-date{
+  font-family:var(--mono);
+  font-size:11px;
+  color:var(--text-faint);
+}
+.release-record .rr-summary{
+  grid-column:1 / -1;
+  font-family:var(--serif);
+  font-size:1.02rem;
+  line-height:1.5;
+  color:var(--text-dim);
+  margin:0;
+}
+.release-record .rr-summary.muted{
+  font-family:var(--mono);
+  font-size:12px;
+  color:var(--text-faint);
+  font-style:normal;
+}
+.release-record .rr-ref{
+  font-family:var(--mono);font-size:11.5px;color:var(--good);text-decoration:none;
+  border:1px solid var(--line-soft);border-radius:7px;padding:2px 8px;
+  display:inline-flex;align-items:center;gap:5px;white-space:nowrap;justify-self:end;
+}
+.release-record .rr-ref:hover{border-color:var(--good);color:var(--text)}
+.release-record .rr-ref:focus-visible{outline:2px solid var(--good);outline-offset:2px}
+
+/* ============================================================
+   3 · §01 PROGRAM BARS
+   ============================================================ */
+.bars{display:grid;gap:16px}
+.bar-row{
+  border:1px solid var(--line-soft);
+  border-radius:var(--radius);
+  background:linear-gradient(165deg,var(--panel),var(--ink-2));
+  padding:18px 20px;
+  box-shadow:var(--shadow);
+}
+.bar-head{
+  display:flex;
+  justify-content:space-between;
+  align-items:flex-start;
+  gap:16px;
+  margin-bottom:14px;
+  flex-wrap:wrap;
+}
+.bar-title{
+  font-family:var(--serif);
+  font-size:1.18rem;
+  display:flex;align-items:center;gap:11px;
+}
+.bar-title .tag{
+  font-family:var(--mono);
+  font-size:11px;
+  text-transform:uppercase;
+  letter-spacing:.08em;
+  color:var(--accent);
+  border:1px solid var(--accent);
+  border-radius:999px;
+  padding:2px 9px;
+  opacity:.9;
+}
+.bar-readout{text-align:right;display:flex;flex-direction:column;align-items:flex-end}
+.bar-readout .pct{
+  font-family:var(--mono);
+  font-size:1.5rem;
+  color:var(--accent);
+  font-weight:600;
+  line-height:1;
+}
+.bar-readout .asof{font-family:var(--mono);font-size:11px;color:var(--text-faint);margin-top:4px}
+.track{
+  height:16px;
+  border-radius:999px;
+  background:var(--ink);
+  border:1px solid var(--line-soft);
+  overflow:hidden;
+  position:relative;
+}
+.fill{
+  height:100%;
+  width:0;
+  background:var(--accent);
+  border-radius:999px;
+  transition:width .55s cubic-bezier(.22,.61,.36,1);
+  position:relative;
+}
+.bar-row.staged .fill::after{
+  content:"";
+  position:absolute;inset:0;
+  background-image:repeating-linear-gradient(45deg,
+     rgba(12,15,20,.0) 0 6px,
+     rgba(12,15,20,.32) 6px 12px);
+}
+.chips{display:flex;flex-wrap:wrap;gap:8px;margin-top:14px}
+.chip{
+  display:inline-flex;
+  align-items:center;
+  gap:7px;
+  font-family:var(--mono);
+  font-size:11.5px;
+  color:var(--text-dim);
+  background:var(--ink-2);
+  border:1px solid var(--line-soft);
+  border-radius:8px;
+  padding:5px 9px;
+  cursor:pointer;
+  transition:opacity .25s ease, border-color .2s ease, background .2s ease;
+}
+.chip:hover{border-color:var(--accent);background:var(--panel)}
+.chip:focus-visible{outline:2px solid var(--good);outline-offset:2px}
+.chip.upcoming{opacity:.42}
+.chip .st{width:9px;height:9px;border-radius:2px;flex:0 0 auto}
+.chip .st.s-prod{background:#fff}
+.chip .st.s-staging{background:var(--good)}
+.chip .st.s-pr{background:var(--ink);border:1px dotted var(--text-dim)}
+.chip .st.s-forecast{background:transparent;border:1px dashed var(--text-faint)}
+
+/* ── Eligibility gating: no weighted snapshot for this release ── */
+.no-snapshot-notice{
+  font-family:var(--mono);
+  font-size:12px;
+  line-height:1.6;
+  color:var(--text-dim);
+  border:1px dashed var(--warn);
+  border-radius:10px;
+  background:var(--ink-2);
+  padding:10px 14px;
+  margin:0 0 16px;
+}
+.no-snapshot-notice[hidden]{display:none}
+.bars.no-snapshot{opacity:.4;filter:saturate(.6)}
+.bars.no-snapshot .bar-row{box-shadow:none}
+
+/* ============================================================
+   4 · §02 VERTICAL DEEP-DIVE TABS
+   ============================================================ */
+.tablist{
+  display:flex;
+  flex-wrap:wrap;
+  gap:4px;
+  border-bottom:1px solid var(--line-soft);
+  margin-bottom:22px;
+}
+.tab{
+  position:relative;
+  display:inline-flex;
+  align-items:center;
+  gap:9px;
+  background:transparent;
+  border:0;
+  color:var(--text-dim);
+  font-family:var(--sans);
+  font-size:.92rem;
+  font-weight:600;
+  padding:11px 14px;
+  cursor:pointer;
+}
+.tab:focus-visible{outline:2px solid var(--good);outline-offset:-2px;border-radius:6px}
+.tab .tdot{width:9px;height:9px;border-radius:50%;background:var(--accent);opacity:.5;transition:opacity .2s ease}
+.tab::after{
+  content:"";
+  position:absolute;left:10px;right:10px;bottom:-1px;height:2px;
+  background:var(--accent);
+  transform:scaleX(0);
+  transform-origin:left;
+  transition:transform .28s cubic-bezier(.22,.61,.36,1);
+}
+.tab[aria-selected="true"]{color:var(--text)}
+.tab[aria-selected="true"] .tdot{opacity:1}
+.tab[aria-selected="true"]::after{transform:scaleX(1)}
+
+.vd-panel[hidden]{display:none}
+.vd-head{display:flex;align-items:center;gap:13px;margin-bottom:8px}
+.vd-head .vsquare{width:18px;height:18px;border-radius:5px;background:var(--accent)}
+.vd-head h3{font-family:var(--serif);font-weight:400;font-size:1.5rem;margin:0}
+.vd-summary{color:var(--text-dim);max-width:66ch;margin:0 0 20px}
+.vd-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.vd-block{
+  border:1px solid var(--line-soft);
+  border-radius:var(--radius);
+  background:var(--panel);
+  padding:16px 18px;
+}
+.vd-block.span2{grid-column:1 / -1}
+.vd-block h4{
+  font-family:var(--mono);
+  font-size:11px;
+  text-transform:uppercase;
+  letter-spacing:.12em;
+  color:var(--text-faint);
+  margin:0 0 12px;
+}
+.vd-block ul{margin:0;padding-left:18px}
+.vd-block li{margin:0 0 7px;color:var(--text-dim)}
+.vd-block li b{color:var(--text);font-weight:600}
+.vd-block code{
+  font-family:var(--mono);font-size:.82em;
+  background:var(--ink);border:1px solid var(--line-soft);
+  border-radius:5px;padding:1px 6px;color:var(--text);margin:0 4px 6px 0;display:inline-block;
+}
+.who-list{display:flex;flex-direction:column;gap:9px}
+.who-item{display:flex;align-items:center;gap:10px;color:var(--text-dim);font-size:.92rem}
+.who-badge{
+  font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.08em;
+  border-radius:999px;padding:2px 9px;flex:0 0 auto;
+}
+.who-badge.paid  {color:var(--good);border:1px solid var(--good)}
+.who-badge.admin {color:#e76ea8;border:1px solid #e76ea8}
+.who-badge.public{color:var(--warn);border:1px solid var(--warn)}
+
+.vtable{width:100%;border-collapse:collapse;font-size:.88rem}
+.vtable th,.vtable td{text-align:left;padding:8px 10px;border-bottom:1px solid var(--line-soft);vertical-align:top}
+.vtable th{font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--text-faint);font-weight:500}
+.vtable td.where{font-family:var(--mono);font-size:.8rem;color:var(--text-dim)}
+.acc-chip{
+  font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.06em;
+  border-radius:999px;padding:1px 8px;
+}
+.acc-chip.paid{color:var(--good);border:1px solid var(--good)}
+.acc-chip.admin{color:#e76ea8;border:1px solid #e76ea8}
+.acc-chip.public{color:var(--warn);border:1px solid var(--warn)}
+.vd-bg{color:var(--text-faint);font-size:.88rem;margin:0}
+
+/* ============================================================
+   5 · §03 CONVERGENCE
+   ============================================================ */
+.conv-row{
+  display:grid;
+  grid-template-columns:1fr auto 1fr;
+  gap:14px;
+  align-items:stretch;
+  margin-bottom:16px;
+}
+.bridge{
+  border:1px solid var(--line-soft);
+  border-radius:var(--radius);
+  background:var(--panel);
+  padding:16px 18px;
+}
+.bridge h4{font-family:var(--serif);font-weight:400;font-size:1.12rem;margin:0 0 8px}
+.bridge p{margin:0;color:var(--text-dim);font-size:.9rem}
+.conv-mid{display:flex;flex-direction:column;align-items:center;justify-content:center;gap:8px;min-width:120px}
+.conv-mid .glyph{font-family:var(--serif);font-size:1.8rem;color:var(--text-dim)}
+.contract-pill{
+  font-family:var(--mono);font-size:11px;
+  color:var(--good);border:1px solid var(--good);
+  border-radius:999px;padding:4px 12px;text-align:center;
+}
+.bridge-status{
+  font-family:var(--mono);font-size:12.5px;color:var(--text-dim);
+  border:1px dashed var(--line);border-radius:10px;
+  padding:10px 14px;margin-bottom:18px;
+}
+.bridge-status b{color:var(--text)}
+.foundation{
+  border:1px dashed var(--line);
+  border-radius:var(--radius);
+  background:var(--ink-2);
+  padding:14px 18px;color:var(--text-faint);font-size:.88rem;
+}
+
+/* ============================================================
+   6 · §04 PROMOTION RECORD
+   ============================================================ */
+.promo-controls{display:flex;align-items:center;gap:12px;margin-bottom:16px;flex-wrap:wrap}
+.align-pill{
+  font-family:var(--mono);font-size:11px;color:var(--text-dim);
+  border:1px solid var(--line);border-radius:999px;padding:4px 12px;
+}
+.show-all{
+  font-family:var(--mono);font-size:11px;color:var(--good);
+  background:transparent;border:1px solid var(--good);border-radius:999px;
+  padding:4px 12px;cursor:pointer;
+}
+.show-all[hidden]{display:none}
+.promo-grid{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.promo-card{
+  border:1px solid var(--line-soft);
+  border-radius:var(--radius);
+  background:var(--panel);
+  padding:16px 18px;
+  transition:opacity .3s ease, box-shadow .3s ease;
+}
+.promo-card.span2{grid-column:1 / -1}
+.promo-grid.filtered .promo-card{opacity:.34}
+.promo-grid.filtered .promo-card.vert-on{
+  opacity:1;
+  box-shadow:0 0 0 1.5px var(--accent), var(--shadow);
+}
+.promo-card h4{
+  font-family:var(--serif);font-weight:400;font-size:1.1rem;margin:0 0 4px;
+  display:flex;align-items:center;gap:9px;
+}
+.promo-card .pcount{font-family:var(--mono);font-size:11px;color:var(--text-faint);margin:0 0 12px}
+.promo-rows{display:flex;flex-direction:column;gap:8px}
+.promo-line{display:flex;align-items:flex-start;gap:10px;font-size:.9rem;color:var(--text-dim)}
+.ppill{
+  font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.06em;
+  border-radius:5px;padding:1px 7px;flex:0 0 auto;margin-top:2px;
+}
+.ppill.stg{color:var(--good);border:1px solid var(--good)}
+.ppill.x{color:var(--text-faint);border:1px solid var(--text-faint)}
+
+/* ============================================================
+   7 · §05 LEVERS
+   ============================================================ */
+.levers{display:grid;grid-template-columns:1fr 1fr;gap:16px}
+.lever{
+  border:1px solid var(--line-soft);
+  border-radius:var(--radius);
+  background:linear-gradient(165deg,var(--panel),var(--ink-2));
+  padding:20px 22px;position:relative;
+}
+.lever.done{border-color:var(--good)}
+.lever .num{
+  font-family:var(--serif);font-weight:400;font-size:2.6rem;line-height:1;
+  color:var(--text-faint);margin-bottom:6px;
+}
+.lever h4{font-family:var(--serif);font-weight:400;font-size:1.2rem;margin:0 0 8px}
+.lever p{margin:0 0 12px;color:var(--text-dim);font-size:.92rem}
+.lever .ship{font-family:var(--mono);font-size:12px;color:var(--good)}
+.lever .donebadge{
+  position:absolute;top:16px;right:18px;
+  font-family:var(--mono);font-size:11px;color:var(--good);
+  border:1px solid var(--good);border-radius:999px;padding:2px 9px;
+}
+
+/* ============================================================
+   8 · §06 DECISIONS LEDGER
+   ============================================================ */
+.ledger{width:100%;border-collapse:collapse;font-size:.92rem}
+.ledger th,.ledger td{text-align:left;padding:11px 12px;border-bottom:1px solid var(--line-soft);vertical-align:top}
+.ledger th{font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.1em;color:var(--text-faint);font-weight:500}
+.ledger td.decision{width:34%;color:var(--text);font-weight:600}
+.ledger td.driven{color:var(--text-dim)}
+.ledger td.evidence{font-family:var(--mono);font-size:.82rem;color:var(--text-dim);white-space:nowrap}
+
+/* ============================================================
+   FOOTER
+   ============================================================ */
+footer.foot{
+  font-family:var(--mono);
+  font-size:12px;
+  color:var(--text-faint);
+  border-top:1px solid var(--line-soft);
+  padding-top:22px;
+  margin-top:8px;
+}
+
+/* ============================================================
+   ERROR / EMPTY
+   ============================================================ */
+.errcard, .emptycard{
+  border:1px solid var(--line-soft);
+  border-radius:var(--radius);
+  background:var(--panel);
+  padding:22px 24px;
+  box-shadow:var(--shadow);
+}
+.errcard{border-left:3px solid var(--warn)}
+.errcard h2{font-family:var(--serif);font-weight:400;font-size:1.4rem;margin:0 0 8px}
+.errcard p{margin:0;color:var(--text-dim)}
+.errcard code{font-family:var(--mono);font-size:.85em;color:var(--warn)}
+.emptycard{color:var(--text-faint);font-family:var(--mono);font-size:13px;text-align:center}
+
+/* ============================================================
+   9 · MODAL
+   ============================================================ */
+.modal-backdrop{
+  position:fixed;inset:0;z-index:100;
+  background:rgba(6,8,12,.72);
+  backdrop-filter:blur(3px);
+  -webkit-backdrop-filter:blur(3px);
+  display:flex;align-items:center;justify-content:center;
+  padding:24px;
+  opacity:0;visibility:hidden;
+  transition:opacity .22s ease, visibility .22s ease;
+}
+.modal-backdrop.on{opacity:1;visibility:visible}
+.modal{
+  width:min(560px,100%);
+  max-height:88vh;overflow:auto;
+  background:linear-gradient(165deg,var(--panel),var(--ink-2));
+  border:1px solid var(--line);
+  border-radius:18px;
+  box-shadow:var(--shadow);
+  padding:26px 28px;
+  transform:scale(.94);
+  transition:transform .26s cubic-bezier(.22,.61,.36,1);
+}
+.modal-backdrop.on .modal{transform:scale(1)}
+.modal-eyebrow{
+  font-family:var(--mono);font-size:11px;letter-spacing:.1em;text-transform:uppercase;
+  color:var(--text-faint);margin:0 0 12px;display:flex;align-items:center;gap:10px;flex-wrap:wrap;
+}
+.rc-badge{
+  font-family:var(--mono);font-size:11px;color:var(--text-dim);
+  border:1px solid var(--line);border-radius:6px;padding:2px 8px;text-transform:none;letter-spacing:0;
+}
+.state-badge{
+  font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.08em;
+  border-radius:999px;padding:2px 9px;
+}
+.state-badge.sb-prod    {color:#fff;border:1px solid #fff}
+.state-badge.sb-staging {color:var(--good);border:1px solid var(--good)}
+.state-badge.sb-pr      {color:var(--text-dim);border:1px dotted var(--text-dim)}
+.state-badge.sb-forecast{color:var(--text-faint);border:1px dashed var(--text-faint)}
+.modal h3{font-family:var(--serif);font-weight:400;font-size:1.7rem;margin:0 0 16px;letter-spacing:-.01em;padding-right:30px}
+.modal-close{
+  position:absolute;top:20px;right:22px;
+  background:transparent;border:0;color:var(--text-dim);
+  font-size:22px;line-height:1;cursor:pointer;border-radius:8px;padding:4px 8px;
+}
+.modal-close:hover{color:var(--text)}
+.modal-close:focus-visible{outline:2px solid var(--good)}
+.modal{position:relative}
+.m-block{margin:0 0 16px}
+.m-block h5{
+  font-family:var(--mono);font-size:10px;text-transform:uppercase;letter-spacing:.12em;
+  color:var(--text-faint);margin:0 0 5px;
+}
+.m-block p{margin:0;color:var(--text-dim)}
+.bk{list-style:none;margin:6px 0 0;padding:0;display:flex;flex-direction:column;gap:6px}
+.bk li{display:flex;justify-content:space-between;gap:12px;font-size:.9rem;color:var(--text-dim);border-bottom:1px dashed var(--line-soft);padding-bottom:6px}
+.bk li .bk-n{font-family:var(--mono);color:var(--text);flex:0 0 auto}
+.bk li .bk-val{font-family:var(--mono);color:var(--good);flex:0 0 auto}
+.gatebadge{
+  display:inline-flex;align-items:center;gap:10px;
+  font-family:var(--mono);font-size:12px;
+  border:1px solid var(--line);border-radius:10px;padding:8px 12px;color:var(--text-dim);
+}
+.gatebadge .g-state{font-weight:600}
+.gatebadge .g-state.live{color:var(--good)}
+.gatebadge .g-state.gated{color:var(--warn)}
+.gatebadge .g-state.forecast{color:var(--text-faint)}
+.modal-links{display:flex;flex-wrap:wrap;gap:8px;margin-top:14px}
+.modal-link{
+  font-family:var(--mono);font-size:12px;color:var(--text-dim);text-decoration:none;
+  border:1px solid var(--line-soft);border-radius:8px;padding:6px 11px;
+  display:inline-flex;align-items:center;gap:7px;
+}
+.modal-link:hover{border-color:var(--accent);color:var(--text)}
+.modal-link .lg{color:var(--accent)}
+
+/* ============================================================
+   RESPONSIVE
+   ============================================================ */
+@media (max-width:760px){
+  .vd-grid{grid-template-columns:1fr}
+  .promo-grid{grid-template-columns:1fr}
+  .levers{grid-template-columns:1fr}
+  .conv-row{grid-template-columns:1fr}
+  .conv-mid{flex-direction:row;min-width:0}
+  /* Ledger reflow → stacked blocks with ::before labels */
+  .ledger thead{display:none}
+  .ledger,.ledger tbody,.ledger tr,.ledger td{display:block;width:auto}
+  .ledger tr{border:1px solid var(--line-soft);border-radius:12px;margin-bottom:12px;padding:6px 4px}
+  .ledger td{border-bottom:1px dashed var(--line-soft)}
+  .ledger td:last-child{border-bottom:0}
+  .ledger td::before{
+    content:attr(data-label);
+    display:block;
+    font-family:var(--mono);font-size:9px;text-transform:uppercase;letter-spacing:.1em;
+    color:var(--text-faint);margin-bottom:3px;
+  }
+  .ledger td.decision{width:auto}
+  .ledger td.evidence{white-space:normal}
+}
+
+/* ============================================================
+   MOTION GATE
+   ============================================================ */
+@media (prefers-reduced-motion: reduce){
+  *{transition:none !important; animation:none !important}
+}
+</style>
+</head>
+<body>
+<a class="skip-link" href="#main">Skip to content</a>
+<div class="wrap">
+  <header class="masthead" id="top">
+    <div class="eyebrow" id="eyebrow"><span class="dot"></span><span id="eyebrow-text"></span></div>
+    <h1 class="title" id="title"></h1>
+    <p class="sub" id="sub"></p>
+    <div class="meta-row" id="meta-row"></div>
+  </header>
+
+  <main id="main"></main>
+
+  <footer class="foot" id="foot"></footer>
+</div>
+
+<!-- Modal shell (populated at runtime) -->
+<div class="modal-backdrop" id="modal-backdrop" aria-hidden="true">
+  <div class="modal" id="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title" tabindex="-1">
+    <button class="modal-close" id="modal-close" aria-label="Close dialog">&times;</button>
+    <div class="modal-eyebrow" id="modal-eyebrow"></div>
+    <h3 id="modal-title"></h3>
+    <div id="modal-body"></div>
+  </div>
+</div>
+
+<script>
+"use strict";
+
+/* ============================================================
+   SMALL HELPERS
+   ============================================================ */
+const $ = (sel, root) => (root || document).querySelector(sel);
+const el = (tag, cls, txt) => {
+  const n = document.createElement(tag);
+  if (cls) n.className = cls;
+  if (txt != null) n.textContent = txt;
+  return n;
+};
+const esc = (s) => String(s == null ? "" : s)
+  .replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;");
+// Allow a SAFE subset of inline markup (<code>, <b>, <em>, <strong>) from trusted JSON.
+// We escape everything, then re-permit the whitelisted tags.
+const richText = (s) => {
+  let h = esc(s);
+  h = h.replace(/&lt;(\/?)(code|b|em|strong)&gt;/g, "<$1$2>");
+  return h;
+};
+const pad2 = (n) => String(n).padStart(2, "0");
+
+const STATE_CLASS = { prod: "s-prod", staging: "s-staging", pr: "s-pr", forecast: "s-forecast" };
+const SB_CLASS    = { prod: "sb-prod", staging: "sb-staging", pr: "sb-pr", forecast: "sb-forecast" };
+
+/* Global runtime state */
+const STATE = {
+  data: null,
+  rcIndexById: {},     // rc id -> index in FULL rcs[] axis (source of truth for cumulative math)
+  selectedRcIndex: 0,  // ALWAYS a full-axis index into rcs[]
+  programs: [],        // [{key,name,accent,phases:[...]}]
+  lastFocusedChip: null,
+  // ── Timeline zoom ──────────────────────────────────────────
+  majors: [],          // [{key:"v5", num:5, label:"v5", repIdx:<fullAxisIdx>, repId, state, members:[{...rc, idx}], count}]
+  zoomMajor: null,     // null = zoomed out (major anchors); otherwise a major key (drilled into that major)
+};
+
+/* ── Semver helpers for major-grouping ─────────────────────── */
+// Parse "v5.4.2" / "5.4.2" → {major, minor, patch}. Missing segments → 0.
+function parseSemver(id) {
+  const m = String(id == null ? "" : id).match(/v?(\d+)(?:\.(\d+))?(?:\.(\d+))?/);
+  if (!m) return { major: 0, minor: 0, patch: 0 };
+  return { major: +m[1], minor: +(m[2] || 0), patch: +(m[3] || 0) };
+}
+// Sort comparator on the full rc record's parsed semver.
+function cmpSemver(a, b) {
+  return (a.major - b.major) || (a.minor - b.minor) || (a.patch - b.patch);
+}
+// "concreteness" of a state for picking a representative (prefers shipped).
+const STATE_RANK = { prod: 3, staging: 2, pr: 1, forecast: 0 };
+
+// Build the major-anchor model from the full ordered rcs[] axis.
+// A major REPRESENTS the highest-semver CONCRETE (shipped/staged/in-PR) release
+// in its group; its pip state is prod if any member shipped, else the rep's state.
+// Trailing forecast-only majors (a major with no concrete releases — e.g. a
+// planned v5.5 whose major has nothing real yet) surface as their OWN forecast
+// anchor instead of being hidden behind a concrete representative.
+function buildMajors(rcs) {
+  const groups = new Map(); // num -> {num, members:[{...rc, idx}]}
+  rcs.forEach((rc, idx) => {
+    const num = parseSemver(rc.id).major;
+    if (!groups.has(num)) groups.set(num, { num, members: [] });
+    groups.get(num).members.push(Object.assign({ idx: idx }, rc, parseSemver(rc.id)));
+  });
+  const majors = [];
+  Array.from(groups.values())
+    .sort((a, b) => a.num - b.num)
+    .forEach((g) => {
+      const members = g.members.slice().sort((x, y) => cmpSemver(x, y) || (x.idx - y.idx));
+      const concrete = members.filter((m) => m.state !== "forecast");
+      const anyProd = members.some((m) => m.state === "prod");
+      // Representative = highest-semver concrete release; if the major has NO
+      // concrete release at all, the highest forecast represents it (forecast major).
+      const rep = concrete.length ? concrete[concrete.length - 1] : members[members.length - 1];
+      majors.push({
+        key: "v" + g.num,
+        num: g.num,
+        label: "v" + g.num,
+        repIdx: rep.idx,        // FULL-axis index — drives cumulative()
+        repId: rep.id,
+        state: anyProd ? "prod" : (rep.state || "forecast"),
+        members: members,
+        count: members.length,
+      });
+    });
+  return majors;
+}
+
+// Which major key contains a given full-axis rc index?
+function majorKeyForRcIndex(rcIndex) {
+  const found = STATE.majors.find((mj) => mj.members.some((m) => m.idx === rcIndex));
+  return found ? found.key : (STATE.majors.length ? STATE.majors[STATE.majors.length - 1].key : null);
+}
+
+/* ============================================================
+   BOOTSTRAP
+   ============================================================ */
+document.addEventListener("DOMContentLoaded", () => {
+  fetch("/api/v1/tracker", { headers: { "Accept": "application/json" } })
+    .then((r) => {
+      if (!r.ok) throw new Error("HTTP " + r.status);
+      return r.json();
+    })
+    .then((data) => render(data))
+    .catch((err) => renderError(err));
+});
+
+function renderError(err) {
+  const main = $("#main");
+  main.innerHTML = "";
+  const card = el("div", "errcard");
+  card.appendChild(el("h2", null, "Couldn’t load the tracker"));
+  const p = el("p");
+  p.innerHTML = "The dashboard data could not be fetched from <code>/api/v1/tracker</code>. "
+    + "Reason: <code>" + esc(err && err.message ? err.message : String(err)) + "</code>.";
+  card.appendChild(p);
+  main.appendChild(card);
+}
+
+/* ============================================================
+   MASTER RENDER
+   ============================================================ */
+function render(data) {
+  STATE.data = data || {};
+  const d = STATE.data;
+
+  // Index rcs (FULL ordered axis — source of truth for cumulative math)
+  const rcs = Array.isArray(d.rcs) ? d.rcs : [];
+  STATE.rcIndexById = {};
+  rcs.forEach((rc, i) => { STATE.rcIndexById[rc.id] = i; });
+
+  // Major-version grouping model for the zoomed-out timeline
+  STATE.majors = buildMajors(rcs);
+
+  // Build program → phases lookup
+  const programs = Array.isArray(d.programs) ? d.programs : [];
+  const phases = Array.isArray(d.phases) ? d.phases : [];
+  STATE.programs = programs.map((p) => ({
+    key: p.key, name: p.name, accent: p.accent,
+    phases: phases.filter((ph) => ph.prog === p.key),
+  }));
+
+  // Initial selection: the major containing the latest prod release, with that
+  // major's REPRESENTATIVE selected (so the default bar = completion as of the
+  // end of that major series). Falls back to the last release's major.
+  STATE.zoomMajor = null; // default view = zoomed out (major anchors)
+  let initIdx = rcs.length - 1;
+  for (let i = rcs.length - 1; i >= 0; i--) {
+    if (rcs[i].state === "prod") { initIdx = i; break; }
+  }
+  initIdx = Math.max(0, initIdx);
+  // Promote to that major's representative full-axis index.
+  if (STATE.majors.length) {
+    const mk = majorKeyForRcIndex(initIdx);
+    const mj = STATE.majors.find((m) => m.key === mk);
+    if (mj) initIdx = mj.repIdx;
+  }
+  STATE.selectedRcIndex = initIdx;
+
+  renderHeader(d);
+  const main = $("#main");
+  main.innerHTML = "";
+
+  let secNum = 0;
+  const nextIdx = () => pad2(++secNum);
+
+  // 1 · Methodology preamble (no section index — it's an intro band)
+  if (d.meta && d.meta.preamble) main.appendChild(buildPreamble(d.meta.preamble));
+
+  // 2 · §01 Release timeline  +  3 · §01 Program bars (share index 01)
+  const relIdx = nextIdx();
+  main.appendChild(buildTimelineSection(rcs, relIdx));
+  main.appendChild(buildProgramBarsSection(relIdx));
+
+  // 4 · §02 Vertical deep-dive
+  main.appendChild(buildVerticalsSection(d.verticals, nextIdx()));
+
+  // 5 · §03 Convergence (optional)
+  if (Array.isArray(d.convergence) && d.convergence.length)
+    main.appendChild(buildConvergenceSection(d.convergence, nextIdx()));
+
+  // 6 · §04 Promotion record (optional)
+  if (Array.isArray(d.promotion) && d.promotion.length)
+    main.appendChild(buildPromotionSection(d.promotion, nextIdx()));
+
+  // 7 · §05 Levers (optional)
+  if (Array.isArray(d.levers) && d.levers.length)
+    main.appendChild(buildLeversSection(d.levers, nextIdx()));
+
+  // 8 · §06 Decisions ledger
+  const ledger = buildLedgerSection(d, nextIdx());
+  if (ledger) main.appendChild(ledger);
+
+  renderFooter(d);
+
+  // Populate the timeline rail now that #timeline is mounted in the document,
+  // then apply the initial selection (drives bars + chips).
+  renderTimelineNodes();
+  selectRelease(STATE.selectedRcIndex, false);
+
+  wireModalShell();
+}
+
+/* ============================================================
+   HEADER / FOOTER
+   ============================================================ */
+function renderHeader(d) {
+  const meta = d.meta || {};
+  $("#eyebrow-text").textContent = meta.eyebrow || "";
+
+  const h1 = $("#title");
+  h1.innerHTML = "";
+  const titleStr = meta.title || "";
+  const titleEm = meta.titleEm || "";
+  if (titleEm && titleStr.includes(titleEm)) {
+    const parts = titleStr.split(titleEm);
+    h1.appendChild(document.createTextNode(parts[0]));
+    const em = el("em", null, titleEm);
+    h1.appendChild(em);
+    h1.appendChild(document.createTextNode(parts.slice(1).join(titleEm)));
+  } else {
+    h1.appendChild(document.createTextNode(titleStr));
+    if (titleEm) { h1.appendChild(document.createTextNode(" ")); h1.appendChild(el("em", null, titleEm)); }
+  }
+
+  $("#sub").textContent = meta.sub || "";
+
+  const mr = $("#meta-row");
+  mr.innerHTML = "";
+  (meta.metaRow || []).forEach((m) => {
+    const item = el("span", "m-item");
+    item.appendChild(el("span", "m-label", m.label));
+    item.appendChild(el("span", "m-value", m.value));
+    mr.appendChild(item);
+  });
+}
+
+function renderFooter(d) {
+  $("#foot").textContent = (d.meta && d.meta.footer) || "";
+}
+
+/* ============================================================
+   1 · PREAMBLE
+   ============================================================ */
+function buildPreamble(text) {
+  const card = el("div", "preamble");
+  card.appendChild(el("div", "glyph", "§"));
+  const p = el("p");
+  p.innerHTML = richText(text);
+  card.appendChild(p);
+  return card;
+}
+
+/* helper: build a <section> with numbered <h2> */
+function buildSection(idx, title, subText) {
+  const sec = el("section", "sec");
+  const h2 = el("h2");
+  h2.appendChild(el("span", "idx", idx));
+  h2.appendChild(document.createTextNode(title));
+  sec.appendChild(h2);
+  if (subText) {
+    const s = el("p", "section-sub");
+    s.innerHTML = richText(subText);
+    sec.appendChild(s);
+  }
+  return sec;
+}
+
+/* ============================================================
+   2 · §01 TIMELINE
+   ============================================================ */
+function buildTimelineSection(rcs, idx) {
+  const sec = buildSection(idx, "Release timeline", "Releases collapse to one anchor per major version. Activate a major to drill into its minor/patch releases; Esc or “zoom out” returns. Selecting any anchor recomputes every program’s shipped percentage against the full release axis.");
+
+  if (!rcs.length) {
+    sec.appendChild(emptyCard("No releases defined yet."));
+    return sec;
+  }
+
+  const wrap = el("div", "timeline-wrap");
+
+  // ── Breadcrumb + zoom-state indicator ──────────────────────
+  const bc = el("div", "tl-breadcrumb");
+  bc.id = "tl-breadcrumb";
+  wrap.appendChild(bc);
+
+  // ── Node rail (populated by renderTimelineNodes) ───────────
+  const tl = el("div", "timeline");
+  tl.id = "timeline";
+  tl.setAttribute("role", "group");
+  tl.setAttribute("aria-label", "Release selector");
+  wrap.appendChild(tl);
+
+  const readout = el("div", "tl-readout");
+  readout.id = "tl-readout";
+  readout.setAttribute("aria-live", "polite");
+  wrap.appendChild(readout);
+
+  // Release record — populated per selection (every pip is self-valuable;
+  // governance doesn't expire, so this always reflects the selected release).
+  const record = el("div", "release-record");
+  record.id = "tl-release-record";
+  record.setAttribute("aria-live", "polite");
+  wrap.appendChild(record);
+
+  // legend
+  const legend = el("div", "tl-legend");
+  [["s-prod", "production"], ["s-staging", "staging"], ["s-pr", "in PR"], ["s-forecast", "forecast"]].forEach(([c, label]) => {
+    const sp = el("span");
+    sp.appendChild(el("span", "sw " + c));
+    sp.appendChild(document.createTextNode(label));
+    legend.appendChild(sp);
+  });
+  wrap.appendChild(legend);
+
+  sec.appendChild(wrap);
+  // NOTE: do NOT call renderTimelineNodes() here — this section subtree isn't in
+  // the document yet, so the #timeline lookup would find nothing. render() calls
+  // it after mount (see below).
+  return sec;
+}
+
+/* Build the list of CURRENTLY VISIBLE anchors for the active zoom level.
+   Each anchor carries a full-axis index (`idx`) so cumulative math is unchanged. */
+function visibleAnchors() {
+  if (STATE.zoomMajor == null) {
+    // Zoomed out: one anchor per major. Selecting it selects the major's representative.
+    return STATE.majors.map((mj) => ({
+      idx: mj.repIdx,
+      id: mj.label,
+      sub: mj.count > 1 ? (mj.repId + " · " + mj.count + " releases") : mj.repId,
+      tag: mj.count > 1 ? (mj.count + " releases") : (mj.state || ""),
+      state: mj.state,
+      isMajor: true,
+      majorKey: mj.key,
+      ariaLabel: mj.label + " — major series, representative " + mj.repId + ", " + mj.count + " release" + (mj.count === 1 ? "" : "s") + ", " + (mj.state || ""),
+    }));
+  }
+  // Zoomed in: every release in the focused major, as individual pips.
+  const mj = STATE.majors.find((m) => m.key === STATE.zoomMajor);
+  if (!mj) return [];
+  return mj.members.map((m) => ({
+    idx: m.idx,
+    id: m.id,
+    sub: m.note || "",
+    tag: m.tag || m.state || "",
+    state: m.state,
+    isMajor: false,
+    majorKey: mj.key,
+    ariaLabel: m.id + " — " + (m.tag || m.state || "") + (m.note ? " — " + m.note : ""),
+  }));
+}
+
+/* (Re)paint the breadcrumb + node rail for the current zoom level. */
+function renderTimelineNodes() {
+  const tl = $("#timeline");
+  if (!tl) return;
+  tl.innerHTML = "";
+
+  // gradient rail segments
+  tl.appendChild(el("div", "rail-solid"));
+  tl.appendChild(el("div", "rail-dash"));
+
+  const anchors = visibleAnchors();
+
+  anchors.forEach((a, vi) => {
+    const node = el("button", "tl-node");
+    node.type = "button";
+    node.setAttribute("aria-pressed", "false");
+    node.dataset.idx = String(a.idx);     // FULL-axis index
+    node.dataset.vi = String(vi);          // visible position
+    node.dataset.major = a.isMajor ? "1" : "0";
+    if (a.majorKey) node.dataset.majorKey = a.majorKey;
+    node.setAttribute("aria-label", a.ariaLabel + (a.isMajor ? " (press Enter to zoom in)" : ""));
+
+    node.appendChild(el("span", "rc-label", a.id));
+    const pip = el("span", "pip " + (STATE_CLASS[a.state] || "s-forecast"));
+    node.appendChild(pip);
+    if (a.sub) node.appendChild(el("span", "rc-sub", a.sub));
+    else node.appendChild(el("span", "rc-tag", a.tag || ""));
+
+    node.addEventListener("click", () => {
+      if (a.isMajor) { zoomIn(a.majorKey, a.idx); }
+      else { selectRelease(a.idx, true); }
+    });
+    node.addEventListener("keydown", (e) => onTimelineKeydown(e, vi, a));
+    tl.appendChild(node);
+  });
+
+  renderBreadcrumb();
+
+  // Re-assert pressed state for whatever full-axis index is selected.
+  document.querySelectorAll("#timeline .tl-node").forEach((n) => {
+    n.setAttribute("aria-pressed", n.dataset.idx === String(STATE.selectedRcIndex) ? "true" : "false");
+  });
+}
+
+/* Keyboard model: ←/→ move among VISIBLE anchors; Enter/Space zoom into a major;
+   Esc zooms out. */
+function onTimelineKeydown(e, vi, a) {
+  const tl = $("#timeline");
+  if (!tl) return;
+  if (e.key === "ArrowRight" || e.key === "ArrowLeft") {
+    e.preventDefault();
+    const nodes = Array.from(tl.querySelectorAll(".tl-node"));
+    const dir = e.key === "ArrowRight" ? 1 : -1;
+    const nextVi = Math.min(nodes.length - 1, Math.max(0, vi + dir));
+    const target = nodes[nextVi];
+    if (target) {
+      selectRelease(parseInt(target.dataset.idx, 10), true);
+      target.focus();
+    }
+  } else if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+    if (a.isMajor) { e.preventDefault(); zoomIn(a.majorKey, a.idx); }
+    // for leaf releases, default button activation (click) already selects
+  } else if (e.key === "Escape") {
+    if (STATE.zoomMajor != null) { e.preventDefault(); zoomOut(); }
+  }
+}
+
+/* Drill into a major: show its minor/patch releases. Select the major's rep. */
+function zoomIn(majorKey, repIdx) {
+  if (majorKey == null) return;
+  STATE.zoomMajor = majorKey;
+  renderTimelineNodes();
+  selectRelease(repIdx != null ? repIdx : STATE.selectedRcIndex, true);
+  // Move focus to the selected (representative) node inside the drilled view.
+  const sel = document.querySelector('#timeline .tl-node[data-idx="' + STATE.selectedRcIndex + '"]');
+  if (sel) sel.focus();
+}
+
+/* Zoom back out to major anchors; keep the selection on the containing major's rep. */
+function zoomOut() {
+  const prevMajor = STATE.zoomMajor;
+  STATE.zoomMajor = null;
+  // Snap selection to the representative of the major we were inside.
+  const mj = STATE.majors.find((m) => m.key === prevMajor)
+    || STATE.majors.find((m) => m.members.some((x) => x.idx === STATE.selectedRcIndex));
+  const targetIdx = mj ? mj.repIdx : STATE.selectedRcIndex;
+  renderTimelineNodes();
+  selectRelease(targetIdx, true);
+  const sel = document.querySelector('#timeline .tl-node[data-idx="' + STATE.selectedRcIndex + '"]');
+  if (sel) sel.focus();
+}
+
+/* Breadcrumb + zoom-state indicator. */
+function renderBreadcrumb() {
+  const bc = $("#tl-breadcrumb");
+  if (!bc) return;
+  bc.innerHTML = "";
+
+  const allBtn = el("button", "crumb crumb-root");
+  allBtn.type = "button";
+  allBtn.textContent = "All majors";
+
+  if (STATE.zoomMajor == null) {
+    allBtn.classList.add("here");
+    allBtn.setAttribute("aria-disabled", "true");
+    bc.appendChild(allBtn);
+    const ind = el("span", "zoom-ind", "zoomed out · " + STATE.majors.length + " majors");
+    bc.appendChild(ind);
+  } else {
+    allBtn.addEventListener("click", () => zoomOut());
+    bc.appendChild(allBtn);
+    bc.appendChild(el("span", "crumb-sep", "▸"));
+    const cur = el("span", "crumb here", STATE.zoomMajor);
+    bc.appendChild(cur);
+    const mj = STATE.majors.find((m) => m.key === STATE.zoomMajor);
+    const ind = el("span", "zoom-ind", "zoomed in · " + (mj ? mj.count : 0) + " release" + (mj && mj.count === 1 ? "" : "s"));
+    bc.appendChild(ind);
+    const out = el("button", "crumb-zoomout", "▢ zoom out");
+    out.type = "button";
+    out.setAttribute("aria-label", "Zoom out to all majors");
+    out.addEventListener("click", () => zoomOut());
+    bc.appendChild(out);
+  }
+}
+
+/* ============================================================
+   3 · §01 PROGRAM BARS
+   ============================================================ */
+function buildProgramBarsSection(idx) {
+  const sec = buildSection(idx, "Program progress", "Weighted completion per program as of the selected release. Diagonal hatch marks staged-but-not-yet-production progress.");
+
+  if (!STATE.programs.length) {
+    sec.appendChild(emptyCard("No programs defined yet."));
+    return sec;
+  }
+
+  // Eligibility notice — shown when the selected release carries no weighted
+  // program snapshot (older minor/patch outside the retroactive window).
+  const notice = el("div", "no-snapshot-notice");
+  notice.id = "bars-no-snapshot-notice";
+  notice.hidden = true;
+  notice.textContent = "Program progress isn’t tracked for this release "
+    + "(older minor/patch outside the retroactive window) — see the release record above.";
+  sec.appendChild(notice);
+
+  const bars = el("div", "bars");
+  bars.id = "program-bars";
+  STATE.programs.forEach((prog) => {
+    const row = el("div", "bar-row");
+    row.style.setProperty("--accent", prog.accent || "var(--good)");
+    row.dataset.prog = prog.key;
+
+    const head = el("div", "bar-head");
+    const title = el("div", "bar-title");
+    title.appendChild(document.createTextNode(prog.name || prog.key));
+    title.appendChild(el("span", "tag", prog.key));
+    head.appendChild(title);
+
+    const ro = el("div", "bar-readout");
+    const pct = el("div", "pct", "0%");
+    pct.dataset.role = "pct";
+    ro.appendChild(pct);
+    const asof = el("div", "asof", "");
+    asof.dataset.role = "asof";
+    ro.appendChild(asof);
+    head.appendChild(ro);
+    row.appendChild(head);
+
+    const track = el("div", "track");
+    const fill = el("div", "fill");
+    fill.dataset.role = "fill";
+    track.appendChild(fill);
+    row.appendChild(track);
+
+    // chips — one per phase of this program
+    const chips = el("div", "chips");
+    prog.phases.forEach((ph) => {
+      const rcIdx = STATE.rcIndexById[ph.rc];
+      const st = rcStateForPhase(ph);
+      const chip = el("button", "chip");
+      chip.type = "button";
+      chip.setAttribute("aria-haspopup", "dialog");
+      chip.dataset.rcidx = String(rcIdx == null ? 999 : rcIdx);
+      chip.appendChild(el("span", "st " + (STATE_CLASS[st] || "s-forecast")));
+      chip.appendChild(document.createTextNode(ph.title || ph.key || ""));
+      chip.addEventListener("click", () => openModal(prog, ph, chip));
+      chips.appendChild(chip);
+    });
+    row.appendChild(chips);
+
+    bars.appendChild(row);
+  });
+
+  sec.appendChild(bars);
+  return sec;
+}
+
+// resolve a phase's display state from the rc it lands in
+function rcStateForPhase(ph) {
+  const rcs = STATE.data.rcs || [];
+  const i = STATE.rcIndexById[ph.rc];
+  if (i == null || !rcs[i]) return "forecast";
+  return rcs[i].state || "forecast";
+}
+
+/* ============================================================
+   WEIGHTED TIMELINE CALCULATOR
+   ============================================================ */
+// cumulative weight for a program's phases whose rc index <= selected
+function cumulative(progKey, rcIndex) {
+  const prog = STATE.programs.find((p) => p.key === progKey);
+  if (!prog) return 0;
+  let sum = 0;
+  prog.phases.forEach((ph) => {
+    const i = STATE.rcIndexById[ph.rc];
+    if (i != null && i <= rcIndex) sum += (Number(ph.w) || 0);
+  });
+  return Math.min(100, Math.round(sum));
+}
+
+// Tiered policy: progressEligible === false means there is NO weighted program
+// snapshot for this release. undefined (or any non-false value) is ELIGIBLE.
+function isProgressEligible(rc) {
+  return !rc || rc.progressEligible !== false;
+}
+
+function selectRelease(rcIndex, animate) {
+  const rcs = STATE.data.rcs || [];
+  if (!rcs.length) return;
+  rcIndex = Math.min(rcs.length - 1, Math.max(0, rcIndex));
+  STATE.selectedRcIndex = rcIndex;
+  const rc = rcs[rcIndex];
+  const staged = rc.state === "staging" || rc.state === "pr";
+  const eligible = isProgressEligible(rc);
+
+  // toggle pressed state on CURRENTLY VISIBLE timeline nodes (matched by full-axis idx)
+  document.querySelectorAll("#timeline .tl-node").forEach((n) => {
+    n.setAttribute("aria-pressed", n.dataset.idx === String(rcIndex) ? "true" : "false");
+  });
+
+  // Eligibility gating — when this release has no weighted snapshot, don't
+  // present a misleading cumulative: surface a notice + de-emphasize the bars,
+  // and HOLD the last eligible bar fills rather than recomputing to this release.
+  const barsBox = $("#program-bars");
+  const notice = $("#bars-no-snapshot-notice");
+  if (barsBox) barsBox.classList.toggle("no-snapshot", !eligible);
+  if (notice) notice.hidden = eligible;
+
+  // recompute each program bar (only when this release has a weighted snapshot)
+  const parts = [];
+  document.querySelectorAll(".bar-row").forEach((row) => {
+    const progKey = row.dataset.prog;
+    const prog = STATE.programs.find((p) => p.key === progKey);
+
+    const fill = row.querySelector('[data-role="fill"]');
+    const pct = row.querySelector('[data-role="pct"]');
+    const asof = row.querySelector('[data-role="asof"]');
+
+    if (!eligible) {
+      // No snapshot for this release: keep the last eligible fill/pct in place
+      // (the notice + de-emphasis make clear the numbers don't apply here).
+      asof.textContent = "no snapshot · " + rc.id;
+      parts.push((prog ? (prog.name || prog.key) : progKey) + " (no snapshot)");
+      return;
+    }
+
+    const val = cumulative(progKey, rcIndex);
+
+    if (!animate) {
+      // suppress transition on init paint
+      const prev = fill.style.transition;
+      fill.style.transition = "none";
+      fill.style.width = val + "%";
+      // force reflow then restore
+      void fill.offsetWidth;
+      fill.style.transition = prev;
+    } else {
+      fill.style.width = val + "%";
+    }
+    pct.textContent = val + "%";
+    asof.textContent = "as of " + rc.id;
+
+    row.classList.toggle("staged", staged && val > 0);
+
+    // dim upcoming chips
+    row.querySelectorAll(".chip").forEach((chip) => {
+      const ci = parseInt(chip.dataset.rcidx, 10);
+      chip.classList.toggle("upcoming", !isNaN(ci) && ci > rcIndex);
+    });
+
+    parts.push((prog ? (prog.name || prog.key) : progKey) + " " + val + "%");
+  });
+
+  // Release record — refresh on EVERY selection (scrub, drill, keyboard).
+  renderReleaseRecord(rc);
+
+  // aria-live readout. When zoomed out, surface the major context too.
+  const readout = $("#tl-readout");
+  if (readout) {
+    readout.innerHTML = "";
+    const line = el("span");
+    let head = "<strong>" + esc(rc.id) + "</strong>";
+    if (STATE.zoomMajor == null) {
+      const mj = STATE.majors.find((m) => m.members.some((x) => x.idx === rcIndex));
+      if (mj && mj.count > 1) head += " <span class=\"ro-major\">(" + esc(mj.label) + " · representative of " + mj.count + ")</span>";
+    }
+    line.innerHTML = head
+      + (rc.note ? " · " + esc(rc.note) : "")
+      + (parts.length ? " — " + parts.map(esc).join(" · ") : "");
+    readout.appendChild(line);
+
+    // Release traceability — governance doesn't expire; older records stay linkable.
+    if (rc.ref) {
+      const a = el("a", "ro-ref");
+      a.href = rc.ref;
+      a.target = "_blank";
+      a.rel = "noopener noreferrer";
+      a.appendChild(document.createTextNode("↗ record"));
+      readout.appendChild(document.createTextNode(" "));
+      readout.appendChild(a);
+    }
+  }
+}
+
+/* Compact "release record" for the selected release — id, date (note), what
+   shipped (summary) + audit link. Updates on EVERY selection because every
+   release stays auditable even when no program snapshot exists for it. */
+function renderReleaseRecord(rc) {
+  const box = $("#tl-release-record");
+  if (!box || !rc) return;
+  box.innerHTML = "";
+
+  box.appendChild(el("span", "rr-id", rc.id || ""));
+  box.appendChild(el("span", "rr-date", rc.note || "—"));
+
+  // Audit link (↗ record) — _blank, rel=noopener — when present.
+  if (rc.ref) {
+    const a = el("a", "rr-ref");
+    a.href = rc.ref;
+    a.target = "_blank";
+    a.rel = "noopener noreferrer";
+    a.appendChild(document.createTextNode("↗ record"));
+    box.appendChild(a);
+  } else {
+    // keep the 3-column grid balanced even without a link
+    box.appendChild(el("span"));
+  }
+
+  // What shipped (summary). Absent on forecasts → muted placeholder.
+  if (rc.summary) {
+    const s = el("p", "rr-summary");
+    s.innerHTML = richText(rc.summary);
+    box.appendChild(s);
+  } else {
+    box.appendChild(el("p", "rr-summary muted", "No changelog summary."));
+  }
+}
+
+/* ============================================================
+   4 · §02 VERTICALS
+   ============================================================ */
+function buildVerticalsSection(verticals, idx) {
+  const sec = buildSection(idx, "Vertical deep-dive", "Per-vertical scope: what it does, who can reach it, the surfaces it ships, and the data behind it.");
+  verticals = Array.isArray(verticals) ? verticals : [];
+
+  if (!verticals.length) {
+    sec.appendChild(emptyCard("No verticals defined yet."));
+    return sec;
+  }
+
+  const tablist = el("div", "tablist");
+  tablist.setAttribute("role", "tablist");
+  tablist.setAttribute("aria-label", "Verticals");
+
+  const panels = [];
+
+  verticals.forEach((v, i) => {
+    const tabId = "tab-" + v.key;
+    const panelId = "panel-" + v.key;
+
+    const tab = el("button", "tab");
+    tab.type = "button";
+    tab.id = tabId;
+    tab.setAttribute("role", "tab");
+    tab.setAttribute("aria-controls", panelId);
+    tab.setAttribute("aria-selected", i === 0 ? "true" : "false");
+    tab.setAttribute("tabindex", i === 0 ? "0" : "-1");
+    tab.style.setProperty("--accent", v.accent || "var(--good)");
+    tab.dataset.vert = v.key;
+    tab.appendChild(el("span", "tdot"));
+    tab.appendChild(document.createTextNode(v.name || v.key));
+    tablist.appendChild(tab);
+
+    const panel = buildVerticalPanel(v, panelId, tabId);
+    panel.hidden = i !== 0;
+    panels.push(panel);
+
+    tab.addEventListener("click", () => activateTab(tablist, panels, i, verticals[i].key));
+  });
+
+  // roving tabindex keyboard pattern
+  tablist.addEventListener("keydown", (e) => {
+    const tabs = Array.from(tablist.querySelectorAll(".tab"));
+    const cur = tabs.findIndex((t) => t.getAttribute("aria-selected") === "true");
+    let next = cur;
+    if (e.key === "ArrowRight") next = (cur + 1) % tabs.length;
+    else if (e.key === "ArrowLeft") next = (cur - 1 + tabs.length) % tabs.length;
+    else if (e.key === "Home") next = 0;
+    else if (e.key === "End") next = tabs.length - 1;
+    else return;
+    e.preventDefault();
+    activateTab(tablist, panels, next, verticals[next].key);
+    tabs[next].focus();
+  });
+
+  sec.appendChild(tablist);
+  panels.forEach((p) => sec.appendChild(p));
+  return sec;
+}
+
+function activateTab(tablist, panels, i, vertKey) {
+  const tabs = Array.from(tablist.querySelectorAll(".tab"));
+  tabs.forEach((t, ti) => {
+    const sel = ti === i;
+    t.setAttribute("aria-selected", sel ? "true" : "false");
+    t.setAttribute("tabindex", sel ? "0" : "-1");
+  });
+  panels.forEach((p, pi) => { p.hidden = pi !== i; });
+  // cross-filter §04 promotion record
+  updateManifest(vertKey);
+}
+
+function buildVerticalPanel(v, panelId, tabId) {
+  const panel = el("div", "vd-panel");
+  panel.id = panelId;
+  panel.setAttribute("role", "tabpanel");
+  panel.setAttribute("aria-labelledby", tabId);
+  panel.setAttribute("tabindex", "0");
+  panel.style.setProperty("--accent", v.accent || "var(--good)");
+
+  const head = el("div", "vd-head");
+  head.appendChild(el("span", "vsquare"));
+  head.appendChild(el("h3", null, v.name || v.key));
+  panel.appendChild(head);
+
+  if (v.summary) {
+    const s = el("p", "vd-summary");
+    s.innerHTML = richText(v.summary);
+    panel.appendChild(s);
+  }
+
+  const grid = el("div", "vd-grid");
+
+  // Functionality
+  if (Array.isArray(v.functionality) && v.functionality.length) {
+    const b = vdBlock("Functionality");
+    const ul = el("ul");
+    v.functionality.forEach((f) => {
+      const li = el("li");
+      li.innerHTML = richText(f);
+      ul.appendChild(li);
+    });
+    b.appendChild(ul);
+    grid.appendChild(b);
+  }
+
+  // Who gets access
+  if (Array.isArray(v.access) && v.access.length) {
+    const b = vdBlock("Who gets access");
+    const list = el("div", "who-list");
+    v.access.forEach((a) => {
+      const item = el("div", "who-item");
+      item.appendChild(el("span", "who-badge " + (a.a || "public"), a.a || "public"));
+      const t = el("span");
+      t.innerHTML = richText(a.t);
+      item.appendChild(t);
+      list.appendChild(item);
+    });
+    b.appendChild(list);
+    grid.appendChild(b);
+  }
+
+  // UI components table (span2)
+  if (Array.isArray(v.components) && v.components.length) {
+    const b = vdBlock("UI components", true);
+    const table = el("table", "vtable");
+    const thead = el("thead");
+    const trh = el("tr");
+    ["Component", "Where", "Who"].forEach((h) => trh.appendChild(el("th", null, h)));
+    thead.appendChild(trh);
+    table.appendChild(thead);
+    const tbody = el("tbody");
+    v.components.forEach((c) => {
+      const tr = el("tr");
+      tr.appendChild(el("td", null, c.c));
+      tr.appendChild(el("td", "where", c.w));
+      const td = el("td");
+      td.appendChild(el("span", "acc-chip " + (c.a || "public"), c.a || "public"));
+      tr.appendChild(td);
+      tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    b.appendChild(table);
+    grid.appendChild(b);
+  }
+
+  // Data & backend (span2)
+  if (Array.isArray(v.backend) && v.backend.length) {
+    const b = vdBlock("Data & backend", true);
+    const wrap = el("div");
+    v.backend.forEach((name) => wrap.appendChild(el("code", null, name)));
+    b.appendChild(wrap);
+    grid.appendChild(b);
+  }
+
+  // Background (optional, span2)
+  if (v.background) {
+    const b = vdBlock("Background", true);
+    const p = el("p", "vd-bg");
+    p.innerHTML = richText(v.background);
+    b.appendChild(p);
+    grid.appendChild(b);
+  }
+
+  panel.appendChild(grid);
+  return panel;
+}
+
+function vdBlock(label, span2) {
+  const b = el("div", "vd-block" + (span2 ? " span2" : ""));
+  b.appendChild(el("h4", null, label));
+  return b;
+}
+
+/* ============================================================
+   5 · §03 CONVERGENCE
+   ============================================================ */
+function buildConvergenceSection(conv, idx) {
+  const sec = buildSection(idx, "Convergence", "Where independent tracks meet a shared contract.");
+  conv.forEach((c) => {
+    const row = el("div", "conv-row");
+
+    const left = el("div", "bridge");
+    if (c.left) {
+      left.appendChild(el("h4", null, c.left.title || ""));
+      const p = el("p"); p.innerHTML = richText(c.left.body); left.appendChild(p);
+    }
+    row.appendChild(left);
+
+    const mid = el("div", "conv-mid");
+    if (c.mid) {
+      mid.appendChild(el("div", "glyph", c.mid.glyph || "⇄"));
+      mid.appendChild(el("div", "contract-pill", c.mid.contract || ""));
+    }
+    row.appendChild(mid);
+
+    const right = el("div", "bridge");
+    if (c.right) {
+      right.appendChild(el("h4", null, c.right.title || ""));
+      const p = el("p"); p.innerHTML = richText(c.right.body); right.appendChild(p);
+    }
+    row.appendChild(right);
+
+    sec.appendChild(row);
+
+    if (c.status) {
+      const st = el("div", "bridge-status");
+      st.innerHTML = richText(c.status);
+      sec.appendChild(st);
+    }
+  });
+  return sec;
+}
+
+/* ============================================================
+   6 · §04 PROMOTION RECORD
+   ============================================================ */
+function buildPromotionSection(promotion, idx) {
+  const sec = buildSection(idx, "Promotion record", "Phase-by-phase staging→production promotion per vertical. Select a deep-dive tab above to cross-filter.");
+
+  const controls = el("div", "promo-controls");
+  const pill = el("span", "align-pill");
+  pill.id = "promo-align-pill";
+  pill.textContent = "Showing all verticals";
+  controls.appendChild(pill);
+  const showAll = el("button", "show-all");
+  showAll.id = "promo-show-all";
+  showAll.textContent = "Show all";
+  showAll.hidden = true;
+  showAll.addEventListener("click", () => updateManifest(null));
+  controls.appendChild(showAll);
+  sec.appendChild(controls);
+
+  const grid = el("div", "promo-grid");
+  grid.id = "promo-grid";
+  promotion.forEach((p) => {
+    const card = el("div", "promo-card" + (p.span2 ? " span2" : ""));
+    if (p.vert) card.dataset.vert = p.vert;
+    if (p.accent) card.style.setProperty("--accent", p.accent);
+
+    const h4 = el("h4", null, p.title || "");
+    card.appendChild(h4);
+    if (p.phaseCount != null) {
+      card.appendChild(el("div", "pcount", p.phaseCount + " phase" + (p.phaseCount === 1 ? "" : "s")));
+    }
+    const rows = el("div", "promo-rows");
+    (p.rows || []).forEach((r) => {
+      const line = el("div", "promo-line");
+      const pc = r.pill === "stg" ? "stg" : "x";
+      line.appendChild(el("span", "ppill " + pc, r.pill === "stg" ? "stg" : "—"));
+      const t = el("span"); t.innerHTML = richText(r.text); line.appendChild(t);
+      rows.appendChild(line);
+    });
+    card.appendChild(rows);
+    grid.appendChild(card);
+  });
+  sec.appendChild(grid);
+  return sec;
+}
+
+// cross-filter §04 by active vertical key (null = show all)
+function updateManifest(vertKey) {
+  const grid = $("#promo-grid");
+  if (!grid) return;
+  const pill = $("#promo-align-pill");
+  const showAll = $("#promo-show-all");
+
+  if (!vertKey) {
+    grid.classList.remove("filtered");
+    grid.querySelectorAll(".promo-card").forEach((c) => c.classList.remove("vert-on"));
+    if (pill) pill.textContent = "Showing all verticals";
+    if (showAll) showAll.hidden = true;
+    return;
+  }
+
+  let any = false;
+  grid.querySelectorAll(".promo-card").forEach((c) => {
+    const match = c.dataset.vert === vertKey;
+    c.classList.toggle("vert-on", match);
+    if (match) any = true;
+  });
+
+  if (any) {
+    grid.classList.add("filtered");
+    if (pill) {
+      const v = (STATE.data.verticals || []).find((x) => x.key === vertKey);
+      pill.textContent = "Aligned to " + (v ? (v.name || v.key) : vertKey);
+    }
+    if (showAll) showAll.hidden = false;
+  } else {
+    // no matching promotion cards → leave unfiltered
+    grid.classList.remove("filtered");
+    if (pill) pill.textContent = "Showing all verticals";
+    if (showAll) showAll.hidden = true;
+  }
+}
+
+/* ============================================================
+   7 · §05 LEVERS
+   ============================================================ */
+function buildLeversSection(levers, idx) {
+  const sec = buildSection(idx, "Levers", "The handful of moves that disproportionately shift the outcome.");
+  const grid = el("div", "levers");
+  levers.forEach((lv) => {
+    const card = el("div", "lever" + (lv.done ? " done" : ""));
+    if (lv.done) card.appendChild(el("span", "donebadge", "1 ✓"));
+    card.appendChild(el("div", "num", lv.num != null ? String(lv.num) : ""));
+    card.appendChild(el("h4", null, lv.title || ""));
+    const p = el("p"); p.innerHTML = richText(lv.body); card.appendChild(p);
+    if (lv.ship) card.appendChild(el("div", "ship", lv.ship));
+    grid.appendChild(card);
+  });
+  sec.appendChild(grid);
+  return sec;
+}
+
+/* ============================================================
+   8 · §06 DECISIONS LEDGER
+   ============================================================ */
+function buildLedgerSection(d, idx) {
+  // Collect decisions: prefer meta.decisions, else derive from verticals/phases.
+  let rows = [];
+  if (d.meta && Array.isArray(d.meta.decisions) && d.meta.decisions.length) {
+    rows = d.meta.decisions.map((r) => ({
+      decision: r.decision || r.d || "",
+      driven: r.driven || r.by || r.drivenBy || "",
+      evidence: r.evidence || r.ev || "",
+    }));
+  } else {
+    // derive from verticals (.decisions) then phases (.decisions)
+    (d.verticals || []).forEach((v) => {
+      (v.decisions || []).forEach((r) => rows.push({
+        decision: r.decision || r.d || "", driven: r.driven || r.by || (v.name || v.key) || "", evidence: r.evidence || r.ev || "",
+      }));
+    });
+    (d.phases || []).forEach((ph) => {
+      (ph.decisions || []).forEach((r) => rows.push({
+        decision: r.decision || r.d || "", driven: r.driven || r.by || (ph.title || ph.key) || "", evidence: r.evidence || r.ev || "",
+      }));
+    });
+  }
+
+  if (!rows.length) return null;
+
+  const sec = buildSection(idx, "Decisions ledger", "Material calls, who drove them, and where the evidence lives.");
+  const table = el("table", "ledger");
+  const thead = el("thead");
+  const trh = el("tr");
+  ["Decision", "Driven by", "Evidence"].forEach((h) => trh.appendChild(el("th", null, h)));
+  thead.appendChild(trh);
+  table.appendChild(thead);
+
+  const tbody = el("tbody");
+  rows.forEach((r) => {
+    const tr = el("tr");
+    const td1 = el("td", "decision"); td1.dataset.label = "Decision"; td1.innerHTML = richText(r.decision); tr.appendChild(td1);
+    const td2 = el("td", "driven"); td2.dataset.label = "Driven by"; td2.innerHTML = richText(r.driven); tr.appendChild(td2);
+    const td3 = el("td", "evidence"); td3.dataset.label = "Evidence"; td3.innerHTML = richText(r.evidence); tr.appendChild(td3);
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  sec.appendChild(table);
+  return sec;
+}
+
+/* ============================================================
+   EMPTY STATE
+   ============================================================ */
+function emptyCard(msg) {
+  return el("div", "emptycard", msg);
+}
+
+/* ============================================================
+   9 · MODAL — open / focus-trap / close
+   ============================================================ */
+function wireModalShell() {
+  const backdrop = $("#modal-backdrop");
+  const closeBtn = $("#modal-close");
+  closeBtn.addEventListener("click", closeModal);
+  backdrop.addEventListener("mousedown", (e) => { if (e.target === backdrop) closeModal(); });
+  document.addEventListener("keydown", (e) => {
+    if (!backdrop.classList.contains("on")) return;
+    if (e.key === "Escape") { e.preventDefault(); closeModal(); }
+    else if (e.key === "Tab") trapFocus(e);
+  });
+}
+
+function trapFocus(e) {
+  const modal = $("#modal");
+  const focusables = modal.querySelectorAll(
+    'a[href], button:not([disabled]), [tabindex]:not([tabindex="-1"])'
+  );
+  if (!focusables.length) return;
+  const first = focusables[0];
+  const last = focusables[focusables.length - 1];
+  if (e.shiftKey && document.activeElement === first) {
+    e.preventDefault(); last.focus();
+  } else if (!e.shiftKey && document.activeElement === last) {
+    e.preventDefault(); first.focus();
+  }
+}
+
+function openModal(prog, ph, triggerChip) {
+  STATE.lastFocusedChip = triggerChip || document.activeElement;
+  const backdrop = $("#modal-backdrop");
+  const modal = $("#modal");
+  modal.style.setProperty("--accent", (prog && prog.accent) || "var(--good)");
+
+  const rcs = STATE.data.rcs || [];
+  const rcIdx = STATE.rcIndexById[ph.rc];
+  const rc = rcIdx != null ? rcs[rcIdx] : null;
+  const state = rc ? (rc.state || "forecast") : "forecast";
+
+  // eyebrow: program · phase-key + RC badge + state badge
+  const eyebrow = $("#modal-eyebrow");
+  eyebrow.innerHTML = "";
+  eyebrow.appendChild(document.createTextNode(((prog && prog.name) || (prog && prog.key) || "") + " · " + (ph.key || "")));
+  if (ph.rc) eyebrow.appendChild(el("span", "rc-badge", ph.rc));
+  eyebrow.appendChild(el("span", "state-badge " + (SB_CLASS[state] || "sb-forecast"), state));
+
+  $("#modal-title").textContent = ph.title || ph.key || "";
+
+  // body
+  const body = $("#modal-body");
+  body.innerHTML = "";
+
+  if (ph.what) body.appendChild(mBlock("What it is", ph.what));
+  if (ph.benefit) body.appendChild(mBlock("Why it matters", ph.benefit));
+
+  // breakdown
+  if (Array.isArray(ph.breakdown) && ph.breakdown.length) {
+    const b = el("div", "m-block");
+    b.appendChild(el("h5", null, "Breakdown"));
+    const ul = el("ul", "bk");
+    ph.breakdown.forEach((bk) => {
+      const li = el("li");
+      li.appendChild(el("span", "bk-n", bk.n));
+      const how = el("span"); how.innerHTML = richText(bk.how); how.style.flex = "1"; how.style.padding = "0 12px";
+      li.appendChild(how);
+      li.appendChild(el("span", "bk-val", bk.val));
+      ul.appendChild(li);
+    });
+    b.appendChild(ul);
+    body.appendChild(b);
+  }
+
+  // Where it sits — gate badge from state + weight
+  const gate = el("div", "m-block");
+  gate.appendChild(el("h5", null, "Where it sits"));
+  const gb = el("div", "gatebadge");
+  let gLabel = "FORECAST", gCls = "forecast";
+  if (state === "prod") { gLabel = "LIVE"; gCls = "live"; }
+  else if (state === "staging" || state === "pr") { gLabel = "BUILT · GATED"; gCls = "gated"; }
+  gb.appendChild(el("span", "g-state " + gCls, gLabel));
+  if (ph.w != null) gb.appendChild(el("span", null, "weight " + ph.w + "%"));
+  gate.appendChild(gb);
+  body.appendChild(gate);
+
+  // links → union: repo issue/PR (t:"issue"|"pr" + n) OR arbitrary URL (t:"url" + href)
+  if (Array.isArray(ph.links) && ph.links.length) {
+    const linksWrap = el("div", "modal-links");
+    const repo = STATE.data.repo || "";
+    ph.links.forEach((lk) => {
+      const a = el("a", "modal-link");
+      a.target = "_blank";
+      a.rel = "noopener noreferrer";
+
+      if (lk.t === "url") {
+        // Arbitrary record (Linear, a doc, a spec) — use href directly.
+        if (!lk.href) return; // skip malformed url entries gracefully
+        a.href = lk.href;
+        a.appendChild(el("span", "lg", "↗"));
+        a.appendChild(document.createTextNode(lk.label || lk.href));
+      } else {
+        // Repo issue / PR — resolve against repo + /issues/ or /pull/ + n.
+        const isPr = lk.t === "pr";
+        const path = isPr ? "/pull/" : "/issues/";
+        a.href = "https://github.com/" + repo + path + lk.n;
+        a.appendChild(el("span", "lg", isPr ? "⌥" : "◆"));
+        a.appendChild(document.createTextNode(lk.label || ((isPr ? "PR #" : "Issue #") + lk.n)));
+      }
+      linksWrap.appendChild(a);
+    });
+    if (linksWrap.childNodes.length) body.appendChild(linksWrap);
+  }
+
+  // show + lock scroll + focus
+  backdrop.classList.add("on");
+  backdrop.setAttribute("aria-hidden", "false");
+  document.body.style.overflow = "hidden";
+  $("#modal-close").focus();
+}
+
+function mBlock(label, text) {
+  const b = el("div", "m-block");
+  b.appendChild(el("h5", null, label));
+  const p = el("p");
+  p.innerHTML = richText(text);
+  b.appendChild(p);
+  return b;
+}
+
+function closeModal() {
+  const backdrop = $("#modal-backdrop");
+  backdrop.classList.remove("on");
+  backdrop.setAttribute("aria-hidden", "true");
+  document.body.style.overflow = "";
+  // restore focus to triggering chip
+  if (STATE.lastFocusedChip && typeof STATE.lastFocusedChip.focus === "function") {
+    STATE.lastFocusedChip.focus();
+  }
+  STATE.lastFocusedChip = null;
+}
+</script>
+</body>
+</html>

--- a/FailSafe/extension/src/test/roadmap/tracker/tracker-model.test.ts
+++ b/FailSafe/extension/src/test/roadmap/tracker/tracker-model.test.ts
@@ -1,0 +1,175 @@
+import { strict as assert } from 'assert';
+import { buildTrackerModel, validateManifest, discoverReleases, isProgramEligible, type TrackerManifest, type TrackerRc } from '../../../roadmap/tracker/tracker-model';
+
+const MANIFEST: TrackerManifest = {
+  repo: 'acme/widget',
+  meta: { title: 'X', footer: 'f' },
+  rcs: [
+    { id: 'v1.0', state: 'forecast', tag: 'planned' },
+    { id: 'v1.1', state: 'forecast', tag: 'planned' },
+  ],
+  programs: [{ key: 'core', name: 'Core', accent: '#0f0' }],
+  phases: [
+    { prog: 'core', key: 'A', rc: 'v1.0', w: 60, title: 'A' },
+    { prog: 'core', key: 'B', rc: 'v1.1', w: 40, title: 'B' },
+  ],
+  verticals: [{ key: 'core', name: 'Core', accent: '#0f0' }],
+};
+
+suite('tracker-model (B-INT-17)', () => {
+  test('buildTrackerModel overlays shipped releases → prod, leaves others declared', () => {
+    const model = buildTrackerModel(MANIFEST, { shippedReleaseIds: ['v1.0'] });
+    assert.equal(model.rcs.find((r) => r.id === 'v1.0')!.state, 'prod', 'shipped → prod');
+    assert.equal(model.rcs.find((r) => r.id === 'v1.1')!.state, 'forecast', 'unshipped stays declared');
+  });
+
+  test('buildTrackerModel with no live data leaves declared states intact', () => {
+    const model = buildTrackerModel(MANIFEST);
+    assert.deepEqual(model.rcs.map((r) => r.state), ['forecast', 'forecast']);
+  });
+
+  test('buildTrackerModel fills empty arrays + omits absent optional sections', () => {
+    const model = buildTrackerModel({ repo: 'a/b' });
+    assert.deepEqual(model.rcs, []);
+    assert.deepEqual(model.programs, []);
+    assert.equal('convergence' in model, false);
+    assert.equal('promotion' in model, false);
+  });
+
+  test('validateManifest: clean weighted model → no findings', () => {
+    assert.deepEqual(validateManifest(MANIFEST), []);
+  });
+
+  test('validateManifest: dangling rc reference → abort', () => {
+    const bad = { ...MANIFEST, phases: [{ prog: 'core', key: 'A', rc: 'v9.9', w: 100, title: 'A' }] };
+    const lint = validateManifest(bad);
+    assert.ok(lint.some((f) => f.severity === 'abort' && f.code === 'phase-unknown-rc'));
+  });
+
+  test('validateManifest: phase referencing an undeclared program → abort', () => {
+    const bad = { ...MANIFEST, phases: [{ prog: 'ghost', key: 'A', rc: 'v1.0', w: 100, title: 'A' }] };
+    assert.ok(validateManifest(bad).some((f) => f.severity === 'abort' && f.code === 'phase-unknown-program'));
+  });
+
+  test('validateManifest: program weights not summing to 100 → warn (non-fatal)', () => {
+    const bad = { ...MANIFEST, phases: [{ prog: 'core', key: 'A', rc: 'v1.0', w: 70, title: 'A' }] };
+    const lint = validateManifest(bad);
+    assert.ok(lint.some((f) => f.severity === 'warn' && f.code === 'program-weight-sum'));
+    assert.ok(!lint.some((f) => f.severity === 'abort'), 'weight mismatch is warn, not abort');
+  });
+
+  // --- release-axis discovery from the CHANGELOG (complete history) ---
+
+  const CHANGELOG = [
+    '# Changelog', '',
+    '## [5.4.2] - 2026-06-03', 'recent', '',
+    '## [1.0.0] - 2026-01-22', 'first stable', '',
+    '## [0.1.0] - 2026-01-22', 'genesis', '',
+  ].join('\n');
+
+  test('discoverReleases parses CHANGELOG headers into prod releases, sorted oldest→newest', () => {
+    const rels = discoverReleases(CHANGELOG);
+    assert.deepEqual(rels.map((r) => r.id), ['v0.1.0', 'v1.0.0', 'v5.4.2']);
+    assert.ok(rels.every((r) => r.state === 'prod'), 'discovered releases are shipped → prod');
+    assert.equal(rels[0].note, '2026-01-22', 'date captured as note');
+  });
+
+  test('discoverReleases dedupes + ignores non-version headings', () => {
+    const rels = discoverReleases('## [1.0.0] - 2026-01-22\n## [1.0.0] - 2026-01-22\n## Unreleased\n');
+    assert.deepEqual(rels.map((r) => r.id), ['v1.0.0']);
+  });
+
+  test('buildTrackerModel: discovered axis (prod, ascending) + manifest forecasts appended', () => {
+    const manifest: TrackerManifest = {
+      programs: [{ key: 'core', name: 'Core', accent: '#0f0' }],
+      rcs: [{ id: 'v6.0', state: 'forecast', tag: 'planned' }],
+      phases: [{ prog: 'core', key: 'A', rc: 'v5.4.2', w: 100, title: 'A' }],
+    };
+    const model = buildTrackerModel(manifest, { discoveredReleases: discoverReleases(CHANGELOG) });
+    assert.deepEqual(model.rcs.map((r) => r.id), ['v0.1.0', 'v1.0.0', 'v5.4.2', 'v6.0']);
+    assert.equal(model.rcs.find((r) => r.id === 'v6.0')!.state, 'forecast', 'forecast stays forecast');
+    assert.equal(model.rcs.find((r) => r.id === 'v5.4.2')!.state, 'prod');
+  });
+
+  test('buildTrackerModel attaches traceability refs: tagged → release/tag, changelog-only → CHANGELOG, forecast → none', () => {
+    const manifest: TrackerManifest = {
+      repo: 'acme/widget',
+      programs: [{ key: 'core', name: 'Core', accent: '#0f0' }],
+      rcs: [{ id: 'v9.0', state: 'forecast', tag: 'planned' }],
+      phases: [{ prog: 'core', key: 'A', rc: 'v1.0.0', w: 100, title: 'A' }],
+    };
+    const model = buildTrackerModel(manifest, {
+      discoveredReleases: discoverReleases(CHANGELOG),
+      shippedReleaseIds: ['v5.4.2'], // tagged
+    });
+    const by = Object.fromEntries(model.rcs.map((r) => [r.id, r]));
+    assert.equal(by['v5.4.2'].ref, 'https://github.com/acme/widget/releases/tag/v5.4.2', 'tagged → release/tag');
+    assert.equal(by['v1.0.0'].ref, 'https://github.com/acme/widget/blob/main/CHANGELOG.md', 'changelog-only → CHANGELOG');
+    assert.equal(by['v9.0'].ref, undefined, 'forecast → no ref');
+  });
+
+  // --- Option A: per-release summary capture ---
+
+  test('discoverReleases captures the entry summary (what shipped), skipping ### sub-headers', () => {
+    const cl = [
+      '## [2.0.0] - 2026-03-01',
+      '### Added',
+      '- Big new thing',
+      '- Another thing',
+      '',
+      'tail ignored',
+      '## [1.0.0] - 2026-01-01',
+      'Just a paragraph.',
+    ].join('\n');
+    const rels = discoverReleases(cl);
+    const by = Object.fromEntries(rels.map((r) => [r.id, r]));
+    assert.match(by['v2.0.0'].summary || '', /Big new thing/);
+    assert.equal(by['v2.0.0'].summary?.includes('Added'), false, '### Added sub-header skipped');
+    assert.match(by['v1.0.0'].summary || '', /Just a paragraph/);
+  });
+
+  // --- tiered program-progress eligibility ---
+
+  const NOW = new Date('2026-06-03T00:00:00Z');
+  const rc = (id: string, note?: string, state: TrackerRc['state'] = 'prod'): TrackerRc => ({ id, state, note });
+
+  test('isProgramEligible: majors are always eligible (full history)', () => {
+    assert.equal(isProgramEligible(rc('v3.0.0', '2025-01-01'), { now: NOW, minorDays: 60, patchDays: 30 }), true);
+  });
+
+  test('isProgramEligible: minors eligible within window, not beyond', () => {
+    assert.equal(isProgramEligible(rc('v5.4.0', '2026-05-20'), { now: NOW, minorDays: 60, patchDays: 30 }), true, 'recent minor');
+    assert.equal(isProgramEligible(rc('v5.1.0', '2026-01-01'), { now: NOW, minorDays: 60, patchDays: 30 }), false, 'old minor (>60d)');
+  });
+
+  test('isProgramEligible: patches use the tighter window', () => {
+    assert.equal(isProgramEligible(rc('v5.4.2', '2026-05-25'), { now: NOW, minorDays: 60, patchDays: 30 }), true, 'recent patch');
+    assert.equal(isProgramEligible(rc('v5.4.1', '2026-04-15'), { now: NOW, minorDays: 60, patchDays: 30 }), false, 'patch >30d');
+  });
+
+  test('isProgramEligible: forecast / undated → eligible (shown)', () => {
+    assert.equal(isProgramEligible(rc('v6.0.0', undefined, 'forecast'), { now: NOW, minorDays: 60, patchDays: 30 }), true);
+    assert.equal(isProgramEligible(rc('v5.9.9', undefined), { now: NOW, minorDays: 60, patchDays: 30 }), true, 'undated → shown');
+  });
+
+  test('buildTrackerModel attaches progressEligible only when now is supplied', () => {
+    const manifest: TrackerManifest = { programs: [{ key: 'c', name: 'C', accent: '#0f0' }], rcs: [] };
+    const disc = discoverReleases('## [3.0.0] - 2026-05-01\nx\n## [3.1.0] - 2026-01-01\ny\n');
+    const withNow = buildTrackerModel(manifest, { discoveredReleases: disc, now: NOW, minorDays: 60, patchDays: 30 });
+    assert.equal(withNow.rcs.find((r) => r.id === 'v3.0.0')!.progressEligible, true, 'major eligible');
+    assert.equal(withNow.rcs.find((r) => r.id === 'v3.1.0')!.progressEligible, false, 'old minor not eligible');
+    const noNow = buildTrackerModel(manifest, { discoveredReleases: disc });
+    assert.equal(noNow.rcs[0].progressEligible, undefined, 'no now → undefined (treated eligible by UI)');
+  });
+
+  test('validateManifest with resolved axis: a phase targeting a DISCOVERED release passes', () => {
+    const manifest: TrackerManifest = {
+      programs: [{ key: 'core', name: 'Core', accent: '#0f0' }],
+      rcs: [],
+      phases: [{ prog: 'core', key: 'A', rc: 'v5.4.2', w: 100, title: 'A' }],
+    };
+    // Without the resolved axis it would be flagged; with it, v5.4.2 is known.
+    assert.ok(validateManifest(manifest).some((f) => f.code === 'phase-unknown-rc'));
+    assert.ok(!validateManifest(manifest, ['v5.4.2']).some((f) => f.code === 'phase-unknown-rc'));
+  });
+});

--- a/FailSafe/extension/src/test/ui/workspace-tab.spec.ts
+++ b/FailSafe/extension/src/test/ui/workspace-tab.spec.ts
@@ -1,9 +1,10 @@
 /**
  * FX521 — B199 Phase 5: Workspace tab Playwright coverage.
  *
- * The Workspace top-level tab hosts 2 sub-views via TabGroup:
+ * The Workspace top-level tab hosts 3 sub-views via TabGroup:
  *   - Skills (SkillsRenderer) — QorLogic skill catalog
  *   - Mindmap (BrainstormRenderer) — Brainstorm canvas
+ *   - Tracker (TrackerEmbedRenderer) — embedded Development Tracker dashboard
  *
  * Phase 5 verifies the tab loads, sub-pills render and switch, content area
  * renders. Deep per-sub-view behavioral coverage (skills install flow,
@@ -28,7 +29,7 @@ async function gotoWorkspace(page: import("@playwright/test").Page, url: string)
   await expect(page.locator('#workspace')).toBeVisible({ timeout: 10000 });
 }
 
-test("FX521 Workspace tab — 2 sub-pills render (Skills / Mindmap)", async ({ page }) => {
+test("FX521 Workspace tab — 3 sub-pills render (Skills / Mindmap / Tracker)", async ({ page }) => {
   controller = await serveConsoleServerUI({
     initialHub: { version: 'test', bootstrapState: {} } as any,
   });
@@ -36,6 +37,8 @@ test("FX521 Workspace tab — 2 sub-pills render (Skills / Mindmap)", async ({ p
   await expect(page.locator('#workspace .cc-subview-bar')).toBeVisible({ timeout: 10000 });
   await expect(page.locator('#workspace .cc-pill[data-key="skills"]')).toBeVisible();
   await expect(page.locator('#workspace .cc-pill[data-key="brainstorm"]')).toBeVisible();
+  await expect(page.locator('#workspace .cc-pill[data-key="tracker"]')).toBeVisible();
+  await expect(page.locator('#workspace .cc-pill')).toHaveCount(3);
 });
 
 test("FX521 Workspace tab — Skills active by default", async ({ page }) => {

--- a/docs/design/DEVELOPMENT_TRACKER_STANDARD.md
+++ b/docs/design/DEVELOPMENT_TRACKER_STANDARD.md
@@ -1,235 +1,57 @@
 # FailSafe Development Tracker — Design Standard
 
-**Status:** v1 design standard (2026-06-02)
+**Status:** v2 design standard (2026-06-03) — premium rebuild (supersedes the v1 lint-row tracker)
 **Artifact name:** Development Tracker (a.k.a. "Status & Implementation Tracker")
-**Hosting:** served by `ConsoleServer` on the existing console port **9376** at `/console/tracker`, data at `/api/v1/tracker`
-**Design source (required citation):** modeled on the Accountable-OS Upgrades status brief — `06-01-2026_Accountable-OS-Upgrades-status.{md,html}` (structure + evidentiary doctrine from the `.md`; visual system + interactive components from the `.html`). Per the FailSafe rule that every UI/UX standard declares its design reference up front.
+**Hosting:** served by `ConsoleServer` on the console port **9376** at `/console/tracker` (the premium engine), data at `/api/v1/tracker` (the generated model). Embedded as a **Workspace-tab sub-view** (iframe) + a **Pop out ↗** affordance + the `FailSafe: Open Development Tracker` command. NOT served from the Monitor.
+**Design source (required citation, per `feedback_design_reference_required`):** `D:\Accountable\STATUS-DASHBOARD-TEMPLATE.md` — the premium (App-tier) status-dashboard: token-first, data-driven, single-file engine; aurora canvas + film grain; Fraunces / Hanken Grotesk / JetBrains Mono; the weighted release-timeline calculator; deep-dive ARIA tabs; modal; decisions ledger. Visually verified in Chromium against this reference.
 
 ---
 
-## 0. What this is
+## 1. Architecture — engine + data, fully decoupled
 
-A single, always-current, evidence-grounded **decision/project/timeline tracker** that FailSafe generates from its own governance artifacts and serves alongside the console. It answers, for any reviewer, three questions with **zero hand-authored opinion**:
+The dashboard is a **reusable generator**, not a FailSafe-specific page. The programs are pure data and differ for every repo/user; FailSafe *generates* a tracker from a manifest + the repo's own history.
 
-1. **How complete is each work vertical?** — scored by artifact-in-tree, not by issue open/closed state.
-2. **What shipped, and where is the proof?** — every claim traces to a PR/SHA, a META_LEDGER entry, a passing test, or a verified runtime fact.
-3. **Why was each decision made?** — every consequential decision traces to the *requirement* (legal floor, binding contract, operator directive) that mandated it — never to preference.
+| Layer | Where | Role |
+|---|---|---|
+| **Engine** | `src/roadmap/ui/tracker/tracker-dashboard.html` | Single static file, zero deps. Fetches `/api/v1/tracker` on load and renders everything from it. No hardcoded content. Ships to `dist/extension/ui/tracker/` via the bundle's recursive UI copy. |
+| **Model builder** | `src/roadmap/tracker/tracker-model.ts` | Pure (`now` injected, no fs/git/Date-in-tests). Merges the planned manifest with the live/discovered layer + validates. |
+| **Manifest (planned layer)** | `docs/roadmap/programs.yaml` | Operator-declared: dynamic-N `programs`, weighted `phases`, `verticals`, forecast `rcs`, `progressWindows`, masthead/footer `meta`. Planning appends here; editing the tracker = editing this. |
+| **Live/discovered layer** | `TrackerRoute` (`src/roadmap/routes/TrackerRoute.ts`) | Reads the manifest + the repo's `CHANGELOG.md` + git tags, calls the model builder, serves `{ ...model, lint, ok }` (data spread at the TOP LEVEL — the engine reads `data.rcs`, `data.meta`, …). |
 
-It is a **read/observe surface** (like the console's other `/console/*` pages): it reports governance truth, it does not gate or enforce. Its rigor is enforced at **generation time** (§7), so an under-evidenced entry never renders as if it were proven.
+## 2. The data model (`/api/v1/tracker`)
 
----
-
-## 1. Core principles (the evidentiary doctrine — binding)
-
-These are lifted directly from the design source's §0 methodology and are the non-negotiable spine of the standard. The template and the generator **must** uphold all five:
-
-| # | Principle | Consequence for the artifact |
-|---|-----------|------------------------------|
-| P1 | **Evidence, not opinion.** Every status number is scored by *artifact-in-tree* — what is merged to `main` / verified applied — not by issue state. | Percentages are **computed** from FailSafe artifacts (§4), never typed by hand. |
-| P2 | **Every claim cites its evidence.** A status, a "shipped" line, a risk, all carry a verifiable reference (PR `#n`, commit SHA, `FX###`, META_LEDGER `Entry #n` + chain hash, test path, or a runtime fact). | No claim renders without ≥1 evidence token. The generator **rejects** uncited claims (§7). |
-| P3 | **Every decision traces to a requirement.** Each decision row names the requirement that drove it (legal/regulatory floor, binding contract/ADR, operator directive) and the evidence that records it. | The Decisions section is a two-column-minimum ledger: `decision → driven-by (requirement) → evidence`. A decision with `driven-by = preference/—` is a **lint failure**. |
-| P4 | **"Done but gated" is never confused with "decided not to do."** Built-but-disabled capabilities state the explicit gate. | A vertical/item may be `built` yet `inert`; the artifact renders the **gate** (e.g., "blocked on legal counsel pass") as first-class, distinct from `not-started` and `descoped`. |
-| P5 | **Traceable to a single source.** Any number must resolve to a merge SHA, a ledger entry, or a workspace artifact fact a reviewer can independently re-derive. | Each rendered value exposes a **provenance affordance** (ⓘ) showing *source + formula* (mirrors the source brief's value-provenance tooltips). |
-
----
-
-## 2. Canonical section schema
-
-Every Development Tracker is composed of these sections, in order. Sections map 1:1 to the design source and bind to FailSafe data (§4). A repo with no data for a section renders it with an explicit "not adopted" note rather than omitting it silently.
-
-| § | Section | Purpose | Render |
-|---|---------|---------|--------|
-| H | **Header** | title, date, scope, **Basis** (the evidence sources this tracker rests on) | header block + 3 summary cards (overall posture / next gate / main constraint) |
-| 1 | **Vertical Completion** | per-vertical % complete, scored-on (evidence), next gate | data-driven **progress bars**, one per vertical, accent-colored |
-| 2 | **Vertical Deep Dive** | per vertical: what's in place / why it matters / open work | **interactive tab + panel** (alternative view of §1) |
-| 3 | **Shipped This Cycle** | the evidence trail: merged-to-`main` + verified-applied, dated | chronological evidence list, every line cited |
-| 4 | **Implementation Manifest** | what is in-tree now (the active base) | area → in-tree evidence table |
-| 5 | **Recommended Sequence** | the dependency-ordered next waves | numbered step strip |
-| 6 | **Decisions → Requirement** | the anti-"feelings" ledger (P3) | `decision · driven-by · evidence` table |
-| 7 | **Risks To Watch** | risk · why it matters · mitigation | table, mitigations cited |
-| 8 | **Convergence** | cross-system / cross-repo bridges + governing contract + status | bridges table |
-| 9 | **Pending Decisions** | operator/legal calls that gate downstream work | `decision · why pending · decider · status` table |
-| F | **Footer** | provenance statement: what window, what evidence range, how to re-verify | monospace provenance line |
-
----
-
-## 3. Data model
-
-The generator produces one JSON document conforming to `TrackerModel`, served at `/api/v1/tracker`. The template renders only from this model (no hand-authored HTML content). Every leaf that makes a claim carries an `evidence[]` array; the generator refuses to emit a claim with an empty `evidence[]` where the schema marks it required (§7).
-
-```ts
-type EvidenceRef =
-  | { kind: 'pr'; number: number; sha?: string; url?: string }
-  | { kind: 'commit'; sha: string }
-  | { kind: 'ledger'; entry: number; chainHash?: string }   // META_LEDGER
-  | { kind: 'feature'; id: string; status: 'verified' | 'unverified' | 'n/a' } // FX###
-  | { kind: 'test'; path: string; result: 'pass' | 'fail' | 'unknown' }
-  | { kind: 'backlog'; id: string }                          // B###
-  | { kind: 'artifact'; path: string; note?: string }        // file-in-tree fact
-  | { kind: 'runtime'; statement: string; verifiedAt: string }; // e.g. a DB/prod fact
-
-interface Provenance { source: string; formula: string; provisional?: boolean }
-
-interface Vertical {
-  key: string; name: string; accent: string;
-  pct: number;                 // COMPUTED (§4) — never hand-set
-  provenance: Provenance;      // how pct was computed
-  scoredOn: { text: string; evidence: EvidenceRef[] };   // evidence required
-  nextGate: string;
-  inPlace: { text: string; evidence: EvidenceRef[] }[];  // each item cited
-  whyItMatters: string;
-  openWork: string[];
-  gate?: { built: boolean; inert: boolean; reason: string }; // P4 "done but gated"
-}
-
-interface Decision { decision: string; drivenBy: string; /* requirement, NOT preference */ evidence: EvidenceRef[]; }
-interface ShippedItem { date: string; channel: 'merged' | 'verified-applied'; text: string; evidence: EvidenceRef[]; }
-interface Risk { risk: string; whyItMatters: string; mitigation: string; evidence: EvidenceRef[]; }
-interface Bridge { left: string; flow: '←' | '→' | '⟷'; right: string; contract: string; status: string; }
-interface PendingDecision { decision: string; whyPending: string; decider: string; status: 'Open' | 'Closed' | 'Deferred' | 'Out of scope'; }
-
-interface TrackerModel {
-  title: string; date: string; scope: string;
-  basis: { text: string; evidence: EvidenceRef[] };
-  summary: { posture: string; nextGate: string; mainConstraint: string };
-  verticals: Vertical[];
-  shipped: ShippedItem[];
-  manifest: { area: string; evidence: EvidenceRef[] }[];
-  sequence: { n: number; title: string; detail: string }[];
-  decisions: Decision[];
-  risks: Risk[];
-  convergence: Bridge[];
-  pending: PendingDecision[];
-  footer: string;
-  generatedAt: string; generatedFrom: EvidenceRef[]; // the artifacts the gen read
-}
+```
+{ repo, meta:{eyebrow,title,titleEm,sub,metaRow,preamble,footer},
+  rcs:      [{ id, state:'prod|staging|pr|forecast', note(=date), ref, summary, progressEligible }],
+  programs: [{ key, name, accent }],          // dynamic N
+  phases:   [{ prog, key, rc, w, title, what, benefit, links:[{t:'issue'|'pr',n}|{t:'url',href}] }],
+  verticals:[{ key, name, accent, summary, functionality, components?, access?, backend? }],
+  lint, ok }
 ```
 
----
+## 3. Release axis — complete history, discovered from the repo
 
-## 4. Data bindings — how FailSafe auto-populates each field
+The timeline spans the **full** history (v0.1.0 → current), because the governance files don't (META_LEDGER only covers recent cycles, git tags are incomplete, GitHub Releases are stale). `discoverReleases(CHANGELOG)` parses every `## [X.Y.Z] - YYYY-MM-DD` header into a `prod` release, ascending, capturing each entry's **summary** (what shipped). The manifest contributes only **forecast** releases (future, not yet in the changelog). Git tags corroborate shipped state.
 
-The whole point: FailSafe owns the evidence, so the tracker is **generated, not written**. Each section binds to existing FailSafe artifacts (all confirmed present in this repo).
+## 4. Timeline zoom — major default, drill to minor+patch
 
-| Field | Source artifact | Binding rule |
-|-------|-----------------|--------------|
-| `verticals[].pct` | `docs/FEATURE_INDEX.md` (FX rows) + `docs/BACKLOG.md` (B-items) | **Computed**: for a vertical's mapped FX/B set, `pct = round(100 · verified / (verified+unverified+open))`. n/a rows excluded. The formula string goes in `provenance.formula`. |
-| `verticals[].scoredOn.evidence` | FEATURE_INDEX FX rows + merged PRs touching the vertical's paths | the FX ids + PR numbers that back the score |
-| `verticals[].gate` (built-but-inert) | BACKLOG item text parsed for gate markers ("gated on", "blocked on", "BUILT but inert") | sets `built:true, inert:true, reason:<gate>` (P4) |
-| `shipped[]` | `git log origin/main` since the cycle base + META_LEDGER seal entries | one item per merged PR / SESSION SEAL; `channel:'verified-applied'` for runtime-verified facts logged in the ledger |
-| `manifest[]` | repo file tree + key tracked artifacts (`src/`, `docs/`, config) | area → `artifact` evidence (paths in-tree) |
-| `decisions[]` | `docs/META_LEDGER.md` (decision/seal entries) + `GOVERNANCE.md` doctrines | each ledger decision → `{decision, drivenBy, evidence:[ledger Entry #, PR]}`. The Merkle chain *is* the provenance. |
-| `risks[]` | BACKLOG risk items + substrate findings + open `FX*` unverified regressions | each cited to its source |
-| `convergence[]` | `docs/GOVERNANCE_INDEX.md` cross-references + integration contract reviews (`docs/research/integrations/`) | bridge rows with governing contract + status |
-| `pending[]` | BACKLOG items tagged operator/legal-gated + open `## Pending` notes | `{decision, whyPending, decider, status}` |
-| `basis` / `footer` | the set of artifacts the generator actually read, with their mtimes/SHAs | makes the tracker self-describing + re-verifiable |
+63 pips is too dense, so the axis **collapses to one anchor per major** (v0 · v1 · … · v5) by default; a major's representative is its highest-semver concrete release. Activating a major **drills in** to its minor/patch releases (breadcrumb + zoom-out + Esc). The weighted `cumulative()` always operates on the **full-axis index** of the selected concrete release, regardless of zoom level.
 
-**Vertical definition.** Verticals are declared once in `docs/design/tracker-verticals.json` (or inferred from BACKLOG section headers), each mapping to a set of `FX`/`B` id-prefixes and `src/` path globs. Adding a vertical is a data edit, not a code change.
+## 5. Two ways the timeline earns its value
 
----
+A full axis with no synchronized program data would be hollow pips. Two complementary mechanisms keep every release meaningful:
 
-## 5. Interactive components — alternative viewing (required)
+- **(A) Traceable record on every pip.** Selecting any release surfaces its `summary` + date + the `↗ record` audit link (GitHub tag/release or CHANGELOG). Governance doesn't expire — a decision made in v2.1.3 stays auditable. Phase `links` additionally carry `issue`/`pr`/arbitrary `url` (Linear, docs) so old decision records are never dead ends.
+- **(B) Tiered program-progress.** The expensive weighted-progress data is populated by tier: **majors for the full history; minors only within `minorDays` (default 60); patches only within `patchDays` (default 30)** — configurable via `progressWindows` in the manifest (and a future `failsafe.tracker.{minor,patch}WindowDays` VS Code setting override). `isProgramEligible(rc, {now, minorDays, patchDays})` is pure (injected `now`). Selecting an **ineligible** release shows a "no program snapshot" notice + de-emphasizes the bars (no misleading cumulative); eligible releases recompute normally.
 
-The artifact must offer **more than one way to read the same evidence**. The design source ships data-driven progress bars + an ARIA tab/panel deep-dive + drill-down tables; this standard requires that set as the floor and adds FailSafe-native affordances:
+## 6. Sections (rendered only when their data is present)
 
-| Component | Alternative view it provides | Behavior |
-|-----------|------------------------------|----------|
-| **Completion bars ⇄ Deep-dive tabs** | the same verticals as at-a-glance bars *or* as detailed per-vertical panels | tab/panel is keyboard-navigable (ArrowLeft/Right/Home/End), `aria-selected`, focus ring — exactly as the source `.html` |
-| **Provenance ⓘ popover** | per value: *source + formula* (P5) | hover/focus reveals `provenance`; provisional values flagged |
-| **Evidence chips** | every claim's `evidence[]` rendered as clickable chips | `pr#122` → PR URL; `Entry #414` → ledger anchor; `FX816` → FEATURE_INDEX anchor; `test:…` → file |
-| **View toggle (cards ⇄ table)** | §3 Shipped and §6 Decisions as a reading list *or* a dense table | one control swaps layout; same data |
-| **Filter chips** | filter Shipped/Decisions/Pending by channel / vertical / status / decider | client-side, no reload |
-| **Density toggle** | comfortable ⇄ compact | persisted in `localStorage` |
-| **Status legend + color encoding** | verticals/bridges color-coded by accent; gate states (`built-inert` vs `open` vs `done`) visually distinct | legend always visible |
-| **"As-of" / freshness badge** | shows `generatedAt` + live-refresh indicator | turns stale → amber if the source artifacts changed but regen hasn't run |
-| **Export** | the current filtered view as Markdown/JSON | re-emits the `.md` form (round-trips to the design source format) |
+Masthead · methodology preamble · **§01 release timeline** (zoom + record) · **§01 program bars** (gradient cards, weighted fill, phase chips → modal) · **§02 vertical deep-dive** (ARIA tabs; components/access tables are *optional* per the "don't owe full component data for everything" rule) · §03 convergence · §04 promotion record (cross-filter) · §05 levers · §06 decisions ledger · modal (focus-trap, gate badge, issue/pr/url links) · provenance footer. A11y + `prefers-reduced-motion` throughout.
 
-All interactivity is **progressive-enhancement** over the rendered model: with JS off, the full evidence still reads as static HTML tables (accessibility floor). No interactive control may hide a claim's evidence — toggles change *layout*, never *what is cited*.
+## 7. Recreation for another repo
 
----
+Swap `programs.yaml` (programs/phases/verticals/forecasts/meta + `repo` + `progressWindows`); the engine, CSS, zoom, calculator, record, and gating are reused verbatim. The release axis + summaries come from that repo's CHANGELOG automatically.
 
-## 6. Hosting model (same port as the console)
+## 8. Tests
 
-FailSafe already serves the console on port **9376** via `ConsoleServer` (Express), with routes registered in `ConsoleRouteRegistrar` and static UI under `express.static(uiDir, { dotfiles: 'allow' })`. The tracker slots into that surface with **no new port and no new server**:
-
-- **Page:** `GET /console/tracker` → serves the tracker template (sibling of the existing `/console/{home,skills,genome,reports,kpi,…}` pages; same `command-center.html` shell + theme).
-- **Data:** `GET /api/v1/tracker` → returns the `TrackerModel` JSON (sibling of `/api/v1/{verdicts,trust}`).
-- **Live updates:** the existing console WebSocket broadcasts a `tracker.refresh` event (alongside the current `hub.refresh`); the page re-fetches `/api/v1/tracker` on receipt.
-- **Theme:** reuse the console design tokens. The design source's palette maps cleanly to the console's dark `bento-tile` theme (near-identical `--bg/--panel/--line` values); per-vertical accents become the FailSafe vertical palette. No bespoke theme — the tracker must look like part of the console.
-
----
-
-## 7. Enforcement — the supporting process that mandates explicit detail
-
-This is what makes "evidence, not opinion" a guarantee rather than a hope. Enforcement runs at **generation time** and again as a **substrate/substantiate gate**, so an under-evidenced tracker cannot be served or sealed.
-
-### 7.1 `tracker_evidence_lint` (the validator)
-A FailSafe-local check (sibling of the substrate modules — same WARN/ABORT vocabulary) that validates a `TrackerModel` against the doctrine (§1):
-
-| Rule | Severity | Fails when |
-|------|----------|-----------|
-| `uncited-claim` | **ABORT** (generation refuses) | any `scoredOn`, `shipped[]`, `risk.mitigation`, or `manifest[]` has empty `evidence[]` |
-| `decision-without-requirement` | **ABORT** | a `decisions[]` row has `drivenBy` empty, "preference", "feelings", or "—" (P3) |
-| `pct-not-computed` | **ABORT** | a `vertical.pct` has no `provenance.formula` resolving to the FX/B set (P1) |
-| `dangling-evidence` | **ABORT** | an `EvidenceRef` does not resolve (PR not merged, `FX###`/`Entry #n` not found, `test` path missing) |
-| `gate-ambiguity` | **WARN** | an item reads "built"/"done" in text but has unverified FX evidence and no `gate` (risks confusing P4 states) |
-| `stale-basis` | **WARN** | `generatedFrom` SHAs lag `origin/main` HEAD (tracker is behind reality) |
-| `provisional-unflagged` | **WARN** | a value sourced from an unverified/`provisional` input renders without the provisional flag |
-
-`uncited-claim`, `decision-without-requirement`, `pct-not-computed`, and `dangling-evidence` are **fail-closed**: the generator emits no tracker (and the page shows the last good model + an error banner) rather than publishing an opinion as fact.
-
-### 7.2 Where it runs
-1. **Generation time** — every regen validates before write; ABORT → keep prior model, surface the finding.
-2. **Substrate run** — `tracker_evidence_lint` joins the substrate module list, so it surfaces in the manual run *and* on every `/qor-substantiate` seal (via the B-SUBSTRATE-3 seal auto-hook).
-3. **CI (optional)** — a PR check renders the model in dry-run and fails on any ABORT-class finding, so a tracker can't be merged with fabricated evidence.
-
----
-
-## 8. Auto-update model
-
-The tracker stays current with **zero manual refresh**, reusing the `WorkspaceMutationBus` already wired in the extension:
-
-1. Register watchers on `docs/META_LEDGER.md`, `docs/BACKLOG.md`, `docs/FEATURE_INDEX.md`, `docs/GOVERNANCE_INDEX.md` (debounced).
-2. On any mutation → regenerate `TrackerModel` → run `tracker_evidence_lint` (§7) → on PASS, write the model + broadcast `tracker.refresh`.
-3. The page re-fetches and re-renders; the freshness badge clears.
-4. A new SESSION SEAL (substantiate) is the strongest trigger — the tracker reflects the just-sealed reality immediately.
-
-This is the same seal-detection mechanism shipped for B-SUBSTRATE-3 (`seal-detection.ts`), generalized to the tracker's source set.
-
----
-
-## 9. Worked example (this repo, today)
-
-A "Governance Substrate" vertical would render — fully generated, fully cited:
-
-- **pct** = `round(100 · verified/(verified+open))` over `FX711–FX713, FX814–FX816` (all `verified`) + open `B-SUBSTRATE-4/5/6` → provenance.formula carries that expression.
-- **scoredOn.evidence** = `[FX711, FX712, FX713, FX814, FX815, FX816, pr#122]`.
-- **shipped** = `merged pr#122 (B-SUBSTRATE-2)`, `branch feat/b-substrate-3 (B-SUBSTRATE-3)` — each a real `EvidenceRef`.
-- **gate** = none (no legal gate); `built:true, inert:false`.
-- **decision** = "Node-port `dependency_admission_lint` (FailSafe-local TS) over upstream contribution" → **drivenBy** = "FailSafe is downstream; substrate pattern is local (FeatureIndexVerifyAdapter precedent)" → **evidence** = `[B-SUBSTRATE-2, pr#122]`.
-
-Nothing in that row is an opinion; every cell resolves to an artifact.
-
----
-
-## 10. Acceptance criteria
-
-- [ ] Renders all sections H,1–9,F from a generated `TrackerModel`; no hand-authored claims.
-- [ ] Every claim carries ≥1 resolving `EvidenceRef`; `tracker_evidence_lint` passes with 0 ABORT findings.
-- [ ] Every `vertical.pct` is computed from FX/B sets with a stated formula.
-- [ ] Every decision names a requirement (never preference) + evidence.
-- [ ] "Built-but-gated" states render distinctly from "open" and "done".
-- [ ] Served at `/console/tracker` + `/api/v1/tracker` on port 9376, console-themed.
-- [ ] Interactive: bars⇄tabs, provenance ⓘ, evidence chips, view/filter/density toggles, export — with a static accessible fallback.
-- [ ] Auto-refreshes on META_LEDGER/BACKLOG/FEATURE_INDEX mutation and on seal.
-
-## 11. Non-goals (v1)
-
-- Not an enforcement gate on operator workflow (observe-only, like the rest of `/console/*`).
-- No editing of the tracker in the UI — it is generated; you change the *evidence*, not the tracker.
-- No cross-repo aggregation in v1 (single-repo; the Convergence section *describes* bridges but does not pull a second repo's live data).
-
-## See also
-- Template: `docs/design/templates/development-tracker.template.html` (the interactive artifact implementing this standard).
-- Design source: `06-01-2026_Accountable-OS-Upgrades-status.{md,html}`.
-- Reused mechanism: `src/qorlogic/substrate/seal-detection.ts` (B-SUBSTRATE-3) for the auto-update trigger.
+`tracker-model.test.ts` covers discovery + summary capture, semver ordering, the discovered+forecast merge, traceability refs, tiered `isProgramEligible` (each tier + window boundaries, injected `now`), and resolved-axis validation. The Workspace-tab Playwright (`workspace-tab.spec.ts`) asserts the Tracker sub-pill. Visual verification is real-pixel (Chromium) per `feedback_design_reference_required`.

--- a/docs/roadmap/programs.yaml
+++ b/docs/roadmap/programs.yaml
@@ -40,6 +40,27 @@ meta:
     - { label: Marketplaces, value: VS Code + Open VSX }
     - { label: In-flight, value: AGT installer }
   footer: Generated from docs/roadmap/programs.yaml + live META_LEDGER/tags. Completion estimates ±~10%. Programs and weights are operator-declared during planning.
+  # Decisions ledger (§06) — the anti-"feelings" register: every call traces to a
+  # requirement + verifiable evidence.
+  decisions:
+    - decision: Release only from main; merge the release branch before tagging
+      drivenBy: Tagging before merge triggers the publish workflow too early; the pre-push hook blocks main
+      evidence: "Release-process lessons; .githooks/pre-push"
+    - decision: Pin the VS Code test version (1.122.1) in the release gate
+      drivenBy: An editor auto-update (1.122.1→1.123.0) broke the better-sqlite3 native build mid-release
+      evidence: "v5.4.0/v5.4.1 dead tags; .vscode-test.mjs + rebuild-vscode-electron.cjs pin"
+    - decision: Run the full test:all suite on every PR to main
+      drivenBy: Native-build + UI regressions were invisible until the release tag fired
+      evidence: ".github/workflows/pr-full-test.yml; two dead tags caught after"
+    - decision: Forward-only dead-tag recovery — never re-use a burned version tag
+      drivenBy: Re-tagging a published version is ambiguous; forward-only stays auditable
+      evidence: "v5.2.x + v5.4.x recovery precedent (META_LEDGER)"
+    - decision: Governed, risk-scored MCP/AGT installs — no silent install
+      drivenBy: High-capability tools (browser automation, agent governance) need admission control
+      evidence: "MCP Catalog #108 scoring; AGT installer run-in-terminal (operator presses enter)"
+    - decision: v5 publicly reveals the FailSafe / FailSafe Pro product split
+      drivenBy: The open-extension vs desktop-daemon boundary needed a public framing
+      evidence: "PRIVATE/docs/LICENSING_POSTURE.md; v5 README reveal"
 
 # Release axis is DISCOVERED from the repo's CHANGELOG (the complete history,
 # v0.1.0 → current — the governance files don't span it). Declare ONLY forecast
@@ -102,3 +123,59 @@ verticals:
     backend:
       - "`ConsoleServer` (Express :9376) + `ConsoleRouteRegistrar`"
       - "`/console/tracker` + `/api/v1/tracker`"
+
+# §03 Convergence — where FailSafe meets adjacent systems at NAMED contracts
+# (not vibes). Each bridge faces a governing contract in the middle.
+convergence:
+  - left:  { title: FailSafe (open extension), body: Editor-boundary governance — audits, skills, checkpoints, MCP/integration admission. }
+    mid:   { glyph: "⟷", contract: Pro feature boundary }
+    right: { title: FailSafe Pro (desktop daemon), body: OS-level enforcement, team workflows, runtime operations beyond the editor. }
+    status: "**Public split revealed in v5** — Pro is now named in the marketplace + Settings."
+  - left:  { title: FailSafe, body: Consumes the SHIELD skill corpus + a version floor. }
+    mid:   { glyph: "→", contract: "qor-logic (PyPI)" }
+    right: { title: qor-logic, body: Deterministic governance engine + SHIELD lifecycle skills. }
+    status: "**Synced to qor-logic 0.102.1** — fail-closed gates adopted."
+  - left:  { title: FailSafe, body: agent-failsafe adapter + the AGT installer surface. }
+    mid:   { glyph: "→", contract: Agent Governance Toolkit }
+    right: { title: Microsoft AGT, body: Per-environment governance modules + agent-sre observability. }
+    status: "**AGT installer in flight (v5.5)** — agent-failsafe adapter is the external bridge."
+
+# §04 Promotion record — what shipped per program (cross-filters on the deep-dive tab).
+promotion:
+  - title: Governance Engine
+    vert: governance
+    accent: "#38d6c8"
+    phaseCount: 3
+    rows:
+      - { pill: stg, text: "SHIELD lifecycle + Merkle-chained ledger (v5.3.3)" }
+      - { pill: stg, text: "Universal governance interceptor — B151 (v5.4.2)" }
+      - { pill: stg, text: "Substrate seal gates + dependency-admission lint (v5.4.2)" }
+  - title: Integrations
+    vert: integrations
+    accent: "#e7b04b"
+    phaseCount: 3
+    rows:
+      - { pill: stg, text: "Bicameral + Open Design L3 write path (v5.3.3)" }
+      - { pill: stg, text: "SARIF · MCP Registry · Slack · MCP Catalog (v5.4.2)" }
+      - { pill: x,   text: "Agent Governance Toolkit installer (v5.5, in flight)" }
+  - title: Experience
+    vert: experience
+    accent: "#f0728f"
+    phaseCount: 3
+    rows:
+      - { pill: stg, text: "Command Center 8-tab browser console (v5.3.3)" }
+      - { pill: x,   text: "Development Tracker — this dashboard (v5.5)" }
+      - { pill: stg, text: "Voice + Mindmap — Whisper/Piper voice pack (v5.3.3)" }
+
+# §05 Levers — the few moves that actually move the numbers.
+levers:
+  - num: "596"
+    title: Verified-feature coverage gate
+    body: Every FEATURE_INDEX entry must carry a test (or a justified n/a) before any marketplace publish.
+    ship: "✓ full-coverage publish gate enforced"
+    done: true
+  - num: "test:all"
+    title: PR-gated full suite
+    body: The complete mocha + Playwright + native-rebuild suite runs on every PR to main, catching regressions before a release tag is ever cut.
+    ship: "✓ pr-full-test.yml live on main"
+    done: true

--- a/docs/roadmap/programs.yaml
+++ b/docs/roadmap/programs.yaml
@@ -1,0 +1,104 @@
+# Development Tracker — programs manifest (the PLANNED layer).
+#
+# This file is the data source for the Development Tracker dashboard
+# (/console/tracker). It is repo-specific and DYNAMIC: the `programs` here are
+# whatever high-level targets/modules this repo is tracking — there is no fixed
+# count. Planning appends to this file; the tracker renders it. The generator
+# (tracker-model.ts) overlays the LIVE layer (which releases actually shipped,
+# from META_LEDGER DELIVER + git tags) and the client computes completion from
+# the weighted phases. Editing the tracker = editing this manifest, never markup.
+#
+# Schema (see docs/design/DEVELOPMENT_TRACKER_STANDARD.md):
+#   repo         GitHub owner/name (modal issue/PR links)
+#   meta         masthead + footer copy
+#   rcs          release axis; `state` is a declared default, overlaid live
+#   programs     dynamic-N high-level targets (key, name, accent)
+#   phases       weighted work items: prog, key, rc (target release), w (weight,
+#                per-program weights ~sum 100), title, what, benefit, links
+#   verticals    deep-dive content per program/area
+
+repo: MythologIQ-Labs-LLC/FailSafe
+
+# Tiered program-progress: majors are tracked for the full history; minors only
+# within minorDays of today, patches only within patchDays. Edit to taste.
+progressWindows:
+  minorDays: 60
+  patchDays: 30
+
+meta:
+  eyebrow: FailSafe · development tracker
+  title: Where the governance surface
+  titleEm: actually is
+  sub: Artifact-in-tree progress across FailSafe's active programs — scrub the release axis to see each program's cumulative completion at any version.
+  preamble: >
+    Scoring is artifact-in-tree, not issue status. A phase counts as landed only
+    when its code + tests are on `main` and the release it targets has shipped to
+    a marketplace — verifiable against META_LEDGER DELIVER entries and git tags,
+    not a checkbox.
+  metaRow:
+    - { label: Released, value: v5.4.2 }
+    - { label: Marketplaces, value: VS Code + Open VSX }
+    - { label: In-flight, value: AGT installer }
+  footer: Generated from docs/roadmap/programs.yaml + live META_LEDGER/tags. Completion estimates ±~10%. Programs and weights are operator-declared during planning.
+
+# Release axis is DISCOVERED from the repo's CHANGELOG (the complete history,
+# v0.1.0 → current — the governance files don't span it). Declare ONLY forecast
+# releases here: future versions not yet shipped / not yet in the changelog.
+rcs:
+  - { id: v5.5, state: forecast, tag: planned, note: AGT installer + next integration tranche }
+
+programs:
+  - { key: governance,   name: Governance Engine, accent: "#38d6c8" }   # teal
+  - { key: integrations, name: Integrations,       accent: "#e7b04b" }   # amber
+  - { key: experience,   name: Experience,         accent: "#f0728f" }   # pink
+
+phases:
+  # Governance Engine
+  - { prog: governance, key: SHIELD,    rc: v5.3.3, w: 40, title: SHIELD lifecycle + ledger, what: Deterministic plan→audit→implement→substantiate→deliver with a Merkle-chained decision ledger., benefit: Governance decisions are code + provenance, not prompt compliance. }
+  - { prog: governance, key: INTERCEPT, rc: v5.4.2, w: 35, title: Universal interceptor, what: Every MCP tool call routes through a single IGovernanceInterceptor seam., benefit: Risky tool invocations are classified + gated like risky edits., links: [ { t: issue, n: 151, label: "B151" } ] }
+  - { prog: governance, key: SUBSTRATE, rc: v5.4.2, w: 25, title: Substrate gates, what: Dependency-admission cooling-period lint + seal auto-hook on every substantiate., benefit: Supply-chain + seal integrity checked every cycle. }
+
+  # Integrations
+  - { prog: integrations, key: BICAMERAL, rc: v5.3.3, w: 25, title: Bicameral + Open Design, what: Architecture-decision governance + L3-gated Open Design create_artifact., benefit: Decision reasoning stays as governed as code. }
+  - { prog: integrations, key: BATCH,     rc: v5.4.2, w: 45, title: SARIF · MCP Registry · Slack · Catalog, what: SARIF ingestion, MCP risk scoring, Slack notify-only, Context7/Mermaid installers., benefit: One governed source of truth across the AI toolchain., links: [ { t: issue, n: 99, label: "#99" }, { t: issue, n: 100, label: "#100" }, { t: issue, n: 108, label: "#108" } ] }
+  - { prog: integrations, key: AGT,       rc: v5.5,   w: 30, title: Agent Governance Toolkit installer, what: Auto-detect the workspace environment + serve the matching verified AGT installer., benefit: Governed admission of Microsoft's AGT modules per environment., links: [ { t: url, href: "https://github.com/microsoft/agent-governance-toolkit", label: AGT upstream }, { t: issue, n: 140, label: "PR #140" } ] }
+
+  # Experience
+  - { prog: experience, key: CONSOLE, rc: v5.3.3, w: 40, title: Command Center, what: Browser-served console — Overview/Operations/Transparency/Governance/Skills/Integrations/Workspace tabs., benefit: One control surface for governance + history. }
+  - { prog: experience, key: TRACKER, rc: v5.5,   w: 30, title: Development Tracker, what: Evidence-enforced, organically-generated status dashboard embedded in the Workspace tab., benefit: Reality-vs-promise visible at a glance, current by construction. }
+  - { prog: experience, key: VOICE,   rc: v5.3.3, w: 30, title: Voice + Mindmap, what: Multilingual Whisper STT + Piper TTS in the Mindmap, shipped as a separate voice pack., benefit: Hands-free ideation that degrades gracefully when absent. }
+
+verticals:
+  - key: governance
+    name: Governance Engine
+    accent: "#38d6c8"
+    summary: Deterministic policy at the editor boundary + a verifiable decision ledger.
+    functionality:
+      - "**Risk classification** L1/L2/L3 by path + content triggers"
+      - "**Sentinel verdicts** PASS / WARN / BLOCK / ESCALATE with confidence"
+      - "**Merkle-chained ledger** every decision append-only + hash-linked"
+    backend:
+      - "`META_LEDGER.md` — chain-verified decision record"
+      - "`EnforcementEngine` + `IGovernanceInterceptor` seam"
+  - key: integrations
+    name: Integrations
+    accent: "#e7b04b"
+    summary: Govern the whole AI toolchain — every integration local-first, opt-in, risk-scored.
+    functionality:
+      - "**SARIF** scanner findings into the risk register"
+      - "**MCP Catalog** governed, env-detected installs (Context7, Mermaid, Playwright)"
+      - "**Slack** VETO / L3 / drift notifications, off by default"
+    backend:
+      - "`src/integrations/*` — pure, injectable-transport clients"
+      - "`/api/v1/mcp/catalog` + `/api/v1/agt/modules`"
+  - key: experience
+    name: Experience
+    accent: "#f0728f"
+    summary: The surfaces operators actually touch — console, learning, voice, tracker.
+    functionality:
+      - "**Command Center** 8-tab browser console on :9376"
+      - "**Learn** SWE-craft education tab"
+      - "**Development Tracker** this dashboard, organically generated"
+    backend:
+      - "`ConsoleServer` (Express :9376) + `ConsoleRouteRegistrar`"
+      - "`/console/tracker` + `/api/v1/tracker`"


### PR DESCRIPTION
## Premium Development Tracker (replaces the lint-row tracker)

A premium, data-driven dashboard at `/console/tracker`, **embedded as a Workspace-tab sub-view** (iframe) + **Pop out ↗** + `FailSafe: Open Development Tracker` command. Built from the **premium (App) tier** of the operator's reference template — start premium, let the data fill it in.

### Architecture (reusable generator; programs are pure per-repo data)
- **Engine** `tracker-dashboard.html` — single static file, fetches `/api/v1/tracker`, renders masthead/preamble/timeline/program-bars/deep-dive-tabs/convergence/promotion/levers/ledger/modal/footer; aurora + film grain, Fraunces/Hanken/JetBrains, full a11y + reduced-motion.
- **Model** `tracker-model.ts` (pure, injected `now`) — full-history CHANGELOG discovery, traceability refs, issue/pr/url links, tiered `isProgramEligible`, validation.
- **Manifest** `docs/roadmap/programs.yaml` — dynamic-N programs + weighted phases + verticals + forecasts + `progressWindows` + masthead copy.

### The two design resolutions you drove
- **Complete history, discovered from the repo** — 63 releases v0.1.0→v5.5 from the CHANGELOG (governance files don't span it). Timeline **zooms**: ~6 major anchors default → drill into a major's minor/patch releases.
- **Every pip earns its value** — (A) a **traceable record** (what shipped + date + ↗ audit link) on every release; (B) **tiered program-progress**: majors full history, minors ≤60d, patches ≤30d (configurable via `progressWindows`). Ineligible releases show a "no snapshot" notice + de-emphasized bars instead of a misleading cumulative.

### Verification (real-pixel, Chromium — Chrome MCP offline)
6 major anchors default · drill v5 → 17 releases · release-record card updates on every selection · gating notice + 0.4-opacity bars on ineligible releases · zero console errors. Model: 20/63 eligible, 62 summaries, lint clean.

### Tests
`tracker-model.test.ts` (discovery + summary + semver merge + refs + tiered eligibility with injected `now` + resolved-axis validation); Workspace pill-count Playwright updated 2→3 incl. the Tracker pill (proactive stale-assertion guard). Runs the full `test:all` gate.

### Notes / deferred
- The old `TrackerGenerator`/`tracker-core`/lint-row path is now **bypassed** (not deleted — its tests still pass; removal is a follow-up).
- `progressWindows` is manifest-configured today; a `failsafe.tracker.*WindowDays` VS Code-settings override is a documented follow-up (registrar is intentionally vscode-free).
- Optional premium sections (convergence/promotion/levers/decisions-ledger) are **template-ready**; they fill from the manifest as data is added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)