### PR TITLE
feat(integrations): read-only Linear issue → intent preview import (#97)

### DIFF
--- a/FailSafe/extension/package.json
+++ b/FailSafe/extension/package.json
@@ -68,7 +68,8 @@
     "onCommand:failsafe.uninstallVoicePack",
     "onCommand:failsafe.substrate.run",
     "onCommand:failsafe.sarif.import",
-    "onCommand:failsafe.mcp.installCatalog"
+    "onCommand:failsafe.mcp.installCatalog",
+    "onCommand:failsafe.linear.import"
   ],
   "main": "./dist/extension/main.js",
   "contributes": {
@@ -125,6 +126,11 @@
       {
         "command": "failsafe.mcp.installCatalog",
         "title": "FailSafe: Install MCP Integration (governed)",
+        "category": "FailSafe"
+      },
+      {
+        "command": "failsafe.linear.import",
+        "title": "FailSafe: Import Linear Issue (preview)",
         "category": "FailSafe"
       },
       {
@@ -310,6 +316,16 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Slack **incoming webhook URL** to post governance notifications to. Treat as a secret — it grants posting to the target channel. Messages are notify-only (no interactive approvals; a link back to the local Command Center is included). Leave empty to disable."
+        },
+        "failsafe.integrations.linear.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable read-only Linear issue import. The `FailSafe: Import Linear Issue (preview)` command resolves a Linear issue URL/identifier to an UNCOMMITTED intent preview — nothing is created or synced. Requires an API key below."
+        },
+        "failsafe.integrations.linear.apiKey": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Linear **personal API key** (or OAuth access token) used for read-only issue lookups. Treat as a secret — prefer a team-scoped, read-only key. The value is sent only in the `Authorization` header and is never logged. Leave empty to disable."
         },
         "failsafe.integrations.openDesign.mcpEnabled": {
           "type": "boolean",

--- a/FailSafe/extension/src/extension/linear-command.ts
+++ b/FailSafe/extension/src/extension/linear-command.ts
@@ -1,0 +1,51 @@
+/**
+ * linear-command — registers `FailSafe: Import Linear Issue (preview)` (B-INT-11
+ * / #97). Prompts for a Linear issue URL/identifier, fetches it read-only via
+ * the Linear GraphQL API, and shows an UNCOMMITTED intent preview. Nothing is
+ * persisted and no FailSafe intent is created — the operator reviews the preview
+ * and decides. Disabled unless an API key is configured. The key is read from
+ * settings and never logged.
+ */
+
+import * as vscode from 'vscode';
+import { fetchLinearIssue, defaultLinearPost } from '../integrations/linear/linear-client';
+
+export function registerLinearImportCommand(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('failsafe.linear.import', async () => {
+      const cfg = vscode.workspace.getConfiguration('failsafe');
+      const enabled = cfg.get<boolean>('integrations.linear.enabled', false);
+      const apiKey = cfg.get<string>('integrations.linear.apiKey', '');
+      if (!enabled || !apiKey) {
+        vscode.window.showWarningMessage(
+          'Linear import is disabled. Enable `failsafe.integrations.linear.enabled` and set a `failsafe.integrations.linear.apiKey`.',
+        );
+        return;
+      }
+      const input = await vscode.window.showInputBox({
+        title: 'Import Linear issue (preview)',
+        prompt: 'Paste a Linear issue URL or identifier (e.g. ENG-123)',
+        ignoreFocusOut: true,
+      });
+      if (!input) return;
+
+      const result = await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Notification, title: 'Fetching Linear issue…' },
+        () => fetchLinearIssue(input, apiKey, defaultLinearPost),
+      );
+
+      if (!result.ok || !result.preview) {
+        vscode.window.showErrorMessage(`Linear import failed: ${result.error ?? 'unknown error'}`);
+        return;
+      }
+      const p = result.preview;
+      const meta = [p.state && `state: ${p.state}`, p.assignee && `assignee: ${p.assignee}`, p.labels.length && `labels: ${p.labels.join(', ')}`]
+        .filter(Boolean).join(' · ');
+      // Preview only — explicitly NOT committed.
+      vscode.window.showInformationMessage(
+        `Intent preview (not committed) — ${p.intent}${meta ? `\n${meta}` : ''}`,
+        { modal: false },
+      );
+    }),
+  );
+}

--- a/FailSafe/extension/src/extension/main.ts
+++ b/FailSafe/extension/src/extension/main.ts
@@ -41,6 +41,7 @@ import { bootstrapStartupChecks } from "./bootstrapStartupChecks";
 import { registerSubstrateCommand } from "./substrate-command";
 import { registerSarifImportCommand } from "./sarif-command";
 import { registerMcpInstallCommand } from "./mcp-install-command";
+import { registerLinearImportCommand } from "./linear-command";
 import { SlackNotifier } from "../integrations/slack/SlackNotifier";
 import { defaultRun } from "../qorlogic/PythonInterpreterResolver";
 

--- a/FailSafe/extension/src/integrations/linear/linear-client.ts
+++ b/FailSafe/extension/src/integrations/linear/linear-client.ts
@@ -1,0 +1,111 @@
+/**
+ * linear-client — thin, injectable transport for FailSafe's read-only Linear
+ * import (B-INT-11 / #97). Resolves a URL/identifier → POSTs the GraphQL query
+ * → returns an UNCOMMITTED intent preview. The `post` transport is injected so
+ * tests use NO live network. The API key is a SECRET: it is placed only in the
+ * outbound Authorization header and is NEVER returned in the result or logged.
+ *
+ * Per the contract review: honor rate-limit response headers, never hardcode a
+ * ceiling (the docs are internally inconsistent). We surface the headers; v1
+ * does not enforce a fixed limit. Non-mutating, non-webhook, read-only.
+ */
+
+import * as https from 'https';
+import {
+  parseLinearIssueId, buildIssueQuery, parseIssueResponse, toIntentPreview,
+  type LinearIntentPreview,
+} from './linear-import';
+
+const LINEAR_GRAPHQL = 'https://api.linear.app/graphql';
+
+export interface LinearPostFn {
+  (url: string, headers: Record<string, string>, body: string):
+    Promise<{ status: number; body: string; headers?: Record<string, string> }>;
+}
+
+export interface LinearRateLimit { remaining?: number; limit?: number; resetAt?: string }
+
+export interface LinearFetchResult {
+  ok: boolean;
+  preview?: LinearIntentPreview;
+  status?: number;
+  rateLimit?: LinearRateLimit;
+  error?: string;
+}
+
+/** Read Linear's rate-limit headers if present (never hardcode a ceiling). */
+export function readRateLimit(headers?: Record<string, string>): LinearRateLimit | undefined {
+  if (!headers) return undefined;
+  const h = (k: string) => headers[k] ?? headers[k.toLowerCase()];
+  const remaining = h('X-RateLimit-Requests-Remaining');
+  const limit = h('X-RateLimit-Requests-Limit');
+  const resetAt = h('X-RateLimit-Requests-Reset');
+  const out: LinearRateLimit = {};
+  if (remaining != null) out.remaining = Number(remaining);
+  if (limit != null) out.limit = Number(limit);
+  if (resetAt != null) out.resetAt = String(resetAt);
+  return Object.keys(out).length ? out : undefined;
+}
+
+/**
+ * Resolve + fetch a Linear issue → uncommitted intent preview. Returns a
+ * structured, non-throwing result. The apiKey never appears in the result.
+ */
+export async function fetchLinearIssue(
+  input: string,
+  apiKey: string | undefined,
+  post: LinearPostFn,
+  endpoint: string = LINEAR_GRAPHQL,
+): Promise<LinearFetchResult> {
+  const id = parseLinearIssueId(input);
+  if (!id) return { ok: false, error: 'Not a Linear issue URL or identifier (expected e.g. ENG-123).' };
+  if (!apiKey || !apiKey.trim()) return { ok: false, error: 'No Linear API key configured.' };
+
+  const req = buildIssueQuery(id);
+  try {
+    const res = await post(
+      endpoint,
+      { 'Content-Type': 'application/json', Authorization: apiKey },
+      JSON.stringify(req),
+    );
+    const rateLimit = readRateLimit(res.headers);
+    if (res.status === 429) return { ok: false, status: 429, error: 'Linear rate limit reached (HTTP 429).', rateLimit };
+    if (res.status === 401 || res.status === 403) return { ok: false, status: res.status, error: 'Linear auth failed — check the API key / token scope.', rateLimit };
+    if (res.status < 200 || res.status >= 300) return { ok: false, status: res.status, error: `Linear returned HTTP ${res.status}.`, rateLimit };
+
+    let json: unknown;
+    try { json = JSON.parse(res.body); } catch { return { ok: false, error: 'Invalid JSON from Linear.', rateLimit }; }
+    const issue = parseIssueResponse(json);
+    if (!issue) return { ok: false, error: `Issue ${id} not found (or no access).`, rateLimit };
+    return { ok: true, preview: toIntentPreview(issue), rateLimit };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** Default https transport (used in production; tests inject their own). */
+export const defaultLinearPost: LinearPostFn = (url, headers, body) =>
+  new Promise((resolve, reject) => {
+    try {
+      const u = new URL(url);
+      const req = https.request(
+        { hostname: u.hostname, path: u.pathname + u.search, method: 'POST',
+          headers: { ...headers, 'Content-Length': Buffer.byteLength(body) }, timeout: 8000 },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (c) => chunks.push(c as Buffer));
+          res.on('end', () => resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+            headers: res.headers as Record<string, string>,
+          }));
+        },
+      );
+      req.on('timeout', () => req.destroy(new Error('timeout')));
+      req.on('error', reject);
+      req.write(body);
+      req.end();
+    } catch (e) {
+      reject(e instanceof Error ? e : new Error(String(e)));
+    }
+  });

--- a/FailSafe/extension/src/integrations/linear/linear-import.ts
+++ b/FailSafe/extension/src/integrations/linear/linear-import.ts
@@ -1,0 +1,135 @@
+/**
+ * linear-import — pure logic for FailSafe's read-only Linear issue → intent
+ * preview import (B-INT-11 / #97, v1). Per the contract review
+ * (INTEGRATION_LINEAR_CONTRACT_REVIEW.md): READ-ONLY. v1 resolves a Linear issue
+ * URL or bare identifier → fetches the canonical fields → presents an
+ * UNCOMMITTED intent preview. NO mutation, NO webhooks (phase two). The auth
+ * token is a secret handled only by the injectable transport (linear-client.ts);
+ * none of these pure functions ever see or carry it.
+ *
+ * All four pieces are pure (no fs/network/secrets) → deterministically tested.
+ */
+
+/** A Linear issue identifier is a team key (uppercase) + number, e.g. ENG-123. */
+const IDENTIFIER_RE = /\b([A-Z][A-Z0-9]*-\d+)\b/;
+
+/**
+ * Resolve a Linear issue URL or a bare identifier to the canonical identifier.
+ *   https://linear.app/acme/issue/ENG-123            → ENG-123
+ *   https://linear.app/acme/issue/ENG-123/some-slug  → ENG-123
+ *   ENG-123                                          → ENG-123
+ * Returns null for anything without a valid identifier (rejects garbage).
+ */
+export function parseLinearIssueId(input: string): string | null {
+  if (typeof input !== 'string') return null;
+  const s = input.trim();
+  if (!s) return null;
+  // URL form: pull the segment right after /issue/.
+  const urlMatch = /\/issue\/([A-Z][A-Z0-9]*-\d+)(?:[/?#]|$)/i.exec(s);
+  if (urlMatch) return urlMatch[1].toUpperCase();
+  // Bare identifier (must be the whole token, not embedded in prose noise).
+  const m = IDENTIFIER_RE.exec(s);
+  if (m && /^[A-Za-z0-9-]+$/.test(s)) return m[1].toUpperCase();
+  return null;
+}
+
+/** The canonical fields v1 reads. `issue(id:)` resolves either the UUID or the
+ *  human identifier (ENG-123) per Linear's documented behavior. */
+export const LINEAR_ISSUE_QUERY =
+  'query FailSafeIssue($id: String!) { issue(id: $id) { ' +
+  'identifier title description priority url ' +
+  'state { name type } assignee { name } labels { nodes { name } } } }';
+
+export interface LinearGraphQLRequest { query: string; variables: { id: string } }
+
+/** Pure GraphQL request builder for a single issue by identifier. */
+export function buildIssueQuery(identifier: string): LinearGraphQLRequest {
+  return { query: LINEAR_ISSUE_QUERY, variables: { id: identifier } };
+}
+
+export interface CanonicalIssue {
+  identifier: string;
+  title: string;
+  description?: string;
+  state?: string;
+  priority?: number;
+  url?: string;
+  assignee?: string;
+  labels: string[];
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim() ? v : undefined;
+}
+
+/**
+ * Defensive parse of a Linear GraphQL response → CanonicalIssue. Tolerates
+ * missing/null fields (Linear omits null relations); returns null when there is
+ * no issue node (not found / GraphQL error). Never reads anything beyond the
+ * canonical fields, so no secret/token in the response could leak through.
+ */
+export function parseIssueResponse(json: unknown): CanonicalIssue | null {
+  const root = (json && typeof json === 'object') ? (json as Record<string, unknown>) : null;
+  const data = root && typeof root.data === 'object' ? (root.data as Record<string, unknown>) : null;
+  const issue = data && data.issue && typeof data.issue === 'object' ? (data.issue as Record<string, unknown>) : null;
+  if (!issue) return null;
+  const identifier = str(issue.identifier);
+  if (!identifier) return null;
+
+  const state = issue.state && typeof issue.state === 'object' ? (issue.state as Record<string, unknown>) : null;
+  const assignee = issue.assignee && typeof issue.assignee === 'object' ? (issue.assignee as Record<string, unknown>) : null;
+  const labelsNode = issue.labels && typeof issue.labels === 'object' ? (issue.labels as Record<string, unknown>) : null;
+  const labelNodes = labelsNode && Array.isArray(labelsNode.nodes) ? (labelsNode.nodes as unknown[]) : [];
+  const labels = labelNodes
+    .map((n) => (n && typeof n === 'object' ? str((n as Record<string, unknown>).name) : undefined))
+    .filter((n): n is string => !!n);
+
+  return {
+    identifier,
+    title: str(issue.title) ?? '(untitled)',
+    description: str(issue.description),
+    state: state ? str(state.name) : undefined,
+    priority: typeof issue.priority === 'number' ? issue.priority : undefined,
+    url: str(issue.url),
+    assignee: assignee ? str(assignee.name) : undefined,
+    labels,
+  };
+}
+
+export interface LinearIntentPreview {
+  source: 'linear';
+  /** UNCOMMITTED: this preview is shown to the operator; nothing is persisted. */
+  committed: false;
+  identifier: string;
+  title: string;
+  /** A concise intent line derived from the issue (no raw secrets, by construction). */
+  intent: string;
+  description?: string;
+  state?: string;
+  priority?: number;
+  assignee?: string;
+  labels: string[];
+  url?: string;
+}
+
+const PRIORITY_LABEL = ['No priority', 'Urgent', 'High', 'Medium', 'Low'];
+
+/** Pure mapper: canonical issue → an UNCOMMITTED FailSafe intent preview. */
+export function toIntentPreview(issue: CanonicalIssue): LinearIntentPreview {
+  const prio = typeof issue.priority === 'number' ? PRIORITY_LABEL[issue.priority] ?? undefined : undefined;
+  const bits = [issue.identifier, issue.title].filter(Boolean);
+  return {
+    source: 'linear',
+    committed: false,
+    identifier: issue.identifier,
+    title: issue.title,
+    intent: bits.join(' — '),
+    description: issue.description,
+    state: issue.state,
+    priority: issue.priority,
+    assignee: issue.assignee,
+    labels: issue.labels,
+    url: issue.url,
+    ...(prio ? { priorityLabel: prio } : {}),
+  } as LinearIntentPreview;
+}

--- a/FailSafe/extension/src/test/integrations/linear/linear.test.ts
+++ b/FailSafe/extension/src/test/integrations/linear/linear.test.ts
@@ -1,0 +1,98 @@
+import { strict as assert } from 'assert';
+import {
+  parseLinearIssueId, buildIssueQuery, parseIssueResponse, toIntentPreview,
+} from '../../../integrations/linear/linear-import';
+import { fetchLinearIssue, readRateLimit, type LinearPostFn } from '../../../integrations/linear/linear-client';
+
+suite('linear-import parse (B-INT-11 #97)', () => {
+  test('resolves a Linear issue URL (with + without slug) to the identifier', () => {
+    assert.equal(parseLinearIssueId('https://linear.app/acme/issue/ENG-123'), 'ENG-123');
+    assert.equal(parseLinearIssueId('https://linear.app/acme/issue/ENG-123/fix-the-thing'), 'ENG-123');
+    assert.equal(parseLinearIssueId('https://linear.app/acme/issue/AB-9?foo=1'), 'AB-9');
+  });
+  test('resolves a bare identifier (case-normalized) and rejects garbage', () => {
+    assert.equal(parseLinearIssueId('ENG-123'), 'ENG-123');
+    assert.equal(parseLinearIssueId('eng-123'), 'ENG-123');
+    assert.equal(parseLinearIssueId('not an id'), null);
+    assert.equal(parseLinearIssueId('https://example.com/whatever'), null);
+    assert.equal(parseLinearIssueId(''), null);
+  });
+});
+
+suite('linear-import query + parse + map (B-INT-11 #97)', () => {
+  test('buildIssueQuery binds the identifier as the $id variable', () => {
+    const q = buildIssueQuery('ENG-7');
+    assert.deepEqual(q.variables, { id: 'ENG-7' });
+    assert.match(q.query, /issue\(id: \$id\)/);
+    assert.match(q.query, /identifier title description/);
+  });
+
+  test('parseIssueResponse tolerates missing/null relations + returns null when no issue', () => {
+    const full = parseIssueResponse({ data: { issue: {
+      identifier: 'ENG-1', title: 'T', description: 'D', priority: 2,
+      state: { name: 'In Progress' }, assignee: { name: 'Ada' }, labels: { nodes: [{ name: 'bug' }, { name: 'p1' }] },
+    } } });
+    assert.equal(full?.state, 'In Progress');
+    assert.deepEqual(full?.labels, ['bug', 'p1']);
+    const sparse = parseIssueResponse({ data: { issue: { identifier: 'ENG-2', title: 'X', assignee: null, labels: null, state: null } } });
+    assert.equal(sparse?.assignee, undefined);
+    assert.deepEqual(sparse?.labels, []);
+    assert.equal(parseIssueResponse({ data: { issue: null } }), null);
+    assert.equal(parseIssueResponse({ errors: [{ message: 'nope' }] }), null);
+  });
+
+  test('toIntentPreview builds an UNCOMMITTED preview (committed:false)', () => {
+    const p = toIntentPreview({ identifier: 'ENG-1', title: 'Fix login', priority: 1, labels: ['bug'] });
+    assert.equal(p.committed, false);
+    assert.equal(p.source, 'linear');
+    assert.match(p.intent, /ENG-1 — Fix login/);
+  });
+});
+
+suite('linear-client (B-INT-11 #97)', () => {
+  const issueBody = JSON.stringify({ data: { issue: { identifier: 'ENG-1', title: 'Fix login', labels: { nodes: [] } } } });
+
+  test('parse failure short-circuits before any network call', async () => {
+    let called = false;
+    const post: LinearPostFn = async () => { called = true; return { status: 200, body: issueBody }; };
+    const r = await fetchLinearIssue('garbage', 'lin_api_xxx', post);
+    assert.equal(r.ok, false);
+    assert.equal(called, false);
+  });
+
+  test('missing api key → error, no network', async () => {
+    let called = false;
+    const post: LinearPostFn = async () => { called = true; return { status: 200, body: issueBody }; };
+    const r = await fetchLinearIssue('ENG-1', '', post);
+    assert.equal(r.ok, false);
+    assert.equal(called, false);
+  });
+
+  test('happy path → uncommitted preview; rate-limit headers surfaced', async () => {
+    const post: LinearPostFn = async () => ({ status: 200, body: issueBody, headers: { 'X-RateLimit-Requests-Remaining': '4999', 'X-RateLimit-Requests-Limit': '5000' } });
+    const r = await fetchLinearIssue('https://linear.app/acme/issue/ENG-1', 'lin_api_secret', post);
+    assert.equal(r.ok, true);
+    assert.equal(r.preview?.committed, false);
+    assert.equal(r.rateLimit?.remaining, 4999);
+  });
+
+  test('SECRET MASKING: the api key passes only in the Authorization header, never in the result', async () => {
+    let sentAuth: string | undefined;
+    const post: LinearPostFn = async (_u, headers) => { sentAuth = headers.Authorization; return { status: 200, body: issueBody }; };
+    const r = await fetchLinearIssue('ENG-1', 'lin_api_TOPSECRET', post);
+    assert.equal(sentAuth, 'lin_api_TOPSECRET', 'key is sent in the Authorization header');
+    assert.ok(!JSON.stringify(r).includes('TOPSECRET'), 'key never appears anywhere in the returned result');
+  });
+
+  test('401/403 → auth error; 429 → rate-limit error (non-throwing)', async () => {
+    const r401 = await fetchLinearIssue('ENG-1', 'k', async () => ({ status: 401, body: '' }));
+    assert.equal(r401.ok, false); assert.match(r401.error ?? '', /auth/i);
+    const r429 = await fetchLinearIssue('ENG-1', 'k', async () => ({ status: 429, body: '' }));
+    assert.equal(r429.ok, false); assert.equal(r429.status, 429);
+  });
+
+  test('readRateLimit is defensive (no headers → undefined)', () => {
+    assert.equal(readRateLimit(undefined), undefined);
+    assert.equal(readRateLimit({}), undefined);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #97 (B-INT-11). Read-only Linear issue import: resolve a Linear issue **URL** (`https://linear.app/<ws>/issue/ENG-123`) or a **bare identifier** (`ENG-123`) → fetch the canonical fields via the Linear GraphQL API → present an **UNCOMMITTED intent preview**. Nothing is created, mutated, synced, or persisted; no FailSafe intent is committed without the operator. No webhooks (deferred to phase two).

## What's in it
- **Pure logic** (`linear-import.ts`): `parseLinearIssueId` (URL + bare, case-normalized, rejects garbage), `buildIssueQuery`, defensive `parseIssueResponse` (tolerates missing/null relations), `toIntentPreview` (`committed: false`).
- **Injectable transport** (`linear-client.ts`): `fetchLinearIssue` (parse → short-circuit before any network on bad input / missing key → POST → 401/403/429/non-2xx handling → preview), `readRateLimit` (surfaces `X-RateLimit-Requests-*` headers; **no hardcoded ceiling** — the published docs are internally inconsistent 2,500 vs 5,000/hr), `defaultLinearPost` https transport.
- **Command**: `FailSafe: Import Linear Issue (preview)`.
- **Config**: `failsafe.integrations.linear.{enabled (default false), apiKey (secret)}`.

## Secret handling
The API key is a **secret**: placed only in the outbound `Authorization` header, **never** returned in the result or logged. A dedicated masking test asserts the key never appears anywhere in `JSON.stringify(result)`.

## Tests (no live network — transport injected)
Parse forms + garbage rejection · query binding · defensive parse (missing/null/no-issue) · uncommitted mapper · short-circuit (garbage + no-key ⇒ zero network) · happy path + rate-limit surfacing · **secret masking** · 401/403 auth · 429 rate-limit. Full `test:all` gate runs on this PR.

## Pattern conformance
Mirrors the established integration shape (pure logic + injectable transport, off by default, secret masked, defensive field access — no ghost fields). Linear GraphQL `issue(id:)` identifier resolution + field paths grounded against the published API; flagged **medium-confidence** pending one live validation against a real workspace key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)