### PR TITLE
chore(security): Tier 1 supply-chain & AI-agent workflow baseline (#90)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,19 @@
+# CODEOWNERS — required review for security-sensitive surfaces.
+# #90 Tier 1 supply-chain baseline.
+#
+# Last matching pattern wins (GitHub semantics). For this file to *enforce*
+# review, the `main` branch ruleset must enable "Require review from Code
+# Owners" — that is an operator settings action (see
+# docs/security/SUPPLY_CHAIN_BASELINE.md → Operator settings follow-ups).
+
+# CI/CD workflows, Actions config, and everything under .github — the highest
+# value supply-chain target (workflow mutation, privileged tokens, secrets).
+/.github/                              @Knapp-Kevin
+
+# Dependency manifests and lockfiles anywhere in the tree — dependency
+# admission control (frozen-install + cooling-period policy live here).
+package.json                           @Knapp-Kevin
+package-lock.json                      @Knapp-Kevin
+
+# The ownership file itself — prevent silent self-service ownership changes.
+/.github/CODEOWNERS                    @Knapp-Kevin

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,21 @@
+# Dependabot — keep SHA-pinned GitHub Actions current. #90 supply-chain
+# baseline. The Tier 1 baseline pins every action to a commit SHA (not a
+# floating tag); Dependabot is the maintenance channel that proposes the next
+# audited SHA + version comment so the pins do not silently rot.
+#
+# Scope is intentionally narrow: github-actions only. npm dependency currency
+# for the extension is handled through the dependency-review gate + the
+# cooling-period policy in docs/security/SUPPLY_CHAIN_BASELINE.md, not by an
+# auto-PR firehose.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    commit-message:
+      prefix: "ci(deps)"
+    labels:
+      - "area:ci"
+      - "dependencies"
+    open-pull-requests-limit: 5

--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -1,0 +1,26 @@
+name: Dependency Review
+
+# Blocks PRs that introduce known-vulnerable dependencies (and surfaces a diff
+# of dependency changes) at the merge gate. Uses the public-repo dependency
+# graph (free; no GHAS required for public repositories). #90 supply-chain
+# baseline → "Require dependency review checks" acceptance criterion.
+on:
+  pull_request:
+    branches: [main]
+
+# Read-only: the action reads the dependency graph via the API. It does NOT
+# comment on the PR (which would require pull-requests: write) — the failing
+# check + the job summary are the signal, keeping the token least-privilege.
+permissions:
+  contents: read
+
+jobs:
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Dependency Review
+        uses: actions/dependency-review-action@a1d282b36b6f3519aa1f3fc636f609c47dddb294 # v5.0.0
+        with:
+          fail-on-severity: high

--- a/.github/workflows/pr-full-test.yml
+++ b/.github/workflows/pr-full-test.yml
@@ -18,13 +18,18 @@ concurrency:
   group: pr-full-test-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
+# Least-privilege default token: these gates only read the repo and
+# build/validate; none mutate repo state. #90 supply-chain baseline.
+permissions:
+  contents: read
+
 jobs:
   full-test:
     name: Full Test Suite (test:all)
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
       - run: npm ci
@@ -37,7 +42,7 @@ jobs:
         working-directory: FailSafe/extension
       - name: Upload Playwright report on failure
         if: ${{ failure() && hashFiles('FailSafe/extension/playwright-report/**') != '' }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: playwright-report
           path: FailSafe/extension/playwright-report/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,12 +19,19 @@ on:
           - feature
           - breaking
 
+# Least-privilege default for the whole pipeline. Publish jobs authenticate via
+# environment secrets (VSCE_PAT / OVSX_TOKEN), not GITHUB_TOKEN, so read is
+# sufficient for them. The github-release job re-grants `contents: write`
+# per-job (it creates the Release object). #90 supply-chain baseline.
+permissions:
+  contents: read
+
 jobs:
   validate:
     name: SemVer 2.0.0 Gate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           fetch-depth: 0 # Full history needed for tag comparison
       - name: Verify tag is on main branch
@@ -47,11 +54,11 @@ jobs:
     needs: validate
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Repository validation gate
         shell: pwsh
         run: ./scripts/validate.ps1 -Version ${{ github.ref_name }}
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
       - run: npm ci
@@ -69,7 +76,7 @@ jobs:
       - name: Upload governance context
         if: ${{ always() && hashFiles('.failsafe-ci-context/**') != '' }}
         continue-on-error: true
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: governance-context
           path: .failsafe-ci-context/
@@ -90,7 +97,7 @@ jobs:
         working-directory: FailSafe/extension
       - run: npm run validate:vsix
         working-directory: FailSafe/extension
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
         with:
           name: vsix
           path: FailSafe/extension/mythologiq-failsafe-${{ env.VSIX_VERSION }}.vsix
@@ -106,7 +113,7 @@ jobs:
     steps:
       - name: Derive release version from tag
         run: echo "VSIX_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: vsix
       - run: npx @vscode/vsce publish --packagePath "mythologiq-failsafe-${VSIX_VERSION}.vsix"
@@ -124,7 +131,7 @@ jobs:
     steps:
       - name: Derive release version from tag
         run: echo "VSIX_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: vsix
       - run: npx ovsx publish "mythologiq-failsafe-${VSIX_VERSION}.vsix"
@@ -144,7 +151,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
       - name: Build release notes from CHANGELOG
         run: |
           VERSION="${GITHUB_REF_NAME#v}"

--- a/.github/workflows/repo-standards-enforcement.yml
+++ b/.github/workflows/repo-standards-enforcement.yml
@@ -16,16 +16,21 @@ on:
       - "release/**"
       - "hotfix/**"
 
+# Least-privilege default token: these gates only read the repo and
+# build/validate; none mutate repo state. #90 supply-chain baseline.
+permissions:
+  contents: read
+
 jobs:
   standards:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
 

--- a/.github/workflows/skills-governance-enforcement.yml
+++ b/.github/workflows/skills-governance-enforcement.yml
@@ -24,13 +24,18 @@ on:
       - "tools/skills/sync-global-codex-skills.ps1"
       - ".github/workflows/skills-governance-enforcement.yml"
 
+# Least-privilege default token: these gates only read the repo and
+# build/validate; none mutate repo state. #90 supply-chain baseline.
+permissions:
+  contents: read
+
 jobs:
   skills-governance:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Validate skill metadata and parity
         shell: pwsh

--- a/.github/workflows/vsix-proprietary-guardrails.yml
+++ b/.github/workflows/vsix-proprietary-guardrails.yml
@@ -11,16 +11,21 @@ on:
       - master
   workflow_dispatch:
 
+# Least-privilege default token: these gates only read the repo and
+# build/validate; none mutate repo state. #90 supply-chain baseline.
+permissions:
+  contents: read
+
 jobs:
   verify-vsix-guardrails:
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
         with:
           node-version: "20"
           cache: npm

--- a/.github/workflows/wiki-init.yml
+++ b/.github/workflows/wiki-init.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
 
       - name: Checkout wiki
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
         with:
           repository: ${{ github.repository }}.wiki
           path: wiki

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,5 +60,13 @@ FailSafe implements multiple security layers:
 
 All security-critical components require L3 risk grade and mandatory `/qor-audit` before changes.
 
+## Supply-Chain & CI Security
+
+FailSafe enforces a Tier 1 supply-chain and AI-agent workflow security baseline
+(minimized Actions tokens, SHA-pinned actions, dependency review, frozen
+installs, CODEOWNERS, and explicit AI-agent action boundaries). See
+[`docs/security/SUPPLY_CHAIN_BASELINE.md`](docs/security/SUPPLY_CHAIN_BASELINE.md)
+for the full control inventory and the operator settings follow-ups.
+
 ---
 _Thank you for helping keep FailSafe secure._

--- a/docs/security/SUPPLY_CHAIN_BASELINE.md
+++ b/docs/security/SUPPLY_CHAIN_BASELINE.md
@@ -1,0 +1,94 @@
+# Tier 1 Supply-Chain & AI-Agent Workflow Security Baseline
+
+> Issue #90 — defenses against Shai-Hulud / Mini Shai-Hulud-class supply-chain
+> attacks affecting dependencies, CI workflows, AI-assisted SDLC execution, and
+> developer tooling. This document records the controls FailSafe enforces, the
+> controls that remain **operator settings actions** (cannot be set from a PR),
+> and the indicators-of-compromise (IOC) review.
+
+## 1. Workflow security baseline
+
+| Control | Status | Where |
+|---|---|---|
+| GitHub Actions default token minimized to read-only | **Enforced** | Every workflow declares a top-level `permissions:` block. Five are `contents: read`; `wiki-init.yml` is `contents: write` (it pushes generated wiki content); `release.yml` is `contents: read` with the `github-release` job re-granting `contents: write` per-job. |
+| Privileged Actions pinned to audited commit SHAs | **Enforced** | All `actions/*` uses are pinned to a full commit SHA with a `# vX.Y.Z` comment. SHAs were resolved from each action's current `@v4` tag (behavior-preserving — no silent major bump). |
+| Pin currency / rot prevention | **Enforced** | `.github/dependabot.yml` (github-actions ecosystem, weekly) proposes the next audited SHA + comment. |
+| CODEOWNERS review for workflows / manifests / lockfiles | **Enforced (file) + operator (ruleset)** | `.github/CODEOWNERS` declares ownership; enforcement requires the `main` ruleset to "Require review from Code Owners" (§4). |
+| Privileged jobs do not restore cache from untrusted PR contexts | **Enforced by design** | No workflow uses `actions/cache` restore in a privileged job. The publish jobs (`release.yml`) run only on `push: tags` (never on `pull_request`), so untrusted PR HEAD never reaches a privileged context. |
+
+## 2. Dependency admission
+
+| Control | Status | Where |
+|---|---|---|
+| Dependency review check | **Enforced** | `.github/workflows/dependency-review.yml` runs `actions/dependency-review-action` on every PR to `main`, `fail-on-severity: high`. |
+| Deterministic / frozen lockfile installs | **Enforced** | All CI installs use `npm ci` (lockfile-frozen, fails on drift), never `npm install`. |
+| Dependency cooling-period policy | **Documented policy** | New direct dependencies (and major bumps) should age **≥ 7 days** on the registry before adoption, to let the ecosystem surface a compromised publish. Dependabot's `github-actions` updates are reviewed under the same window. |
+| Disable install/lifecycle scripts where practical | **Partial / documented** | Lifecycle scripts cannot be globally disabled in CI because the build legitimately requires native rebuilds (`better-sqlite3`) and `playwright install`. Scripts run only against the **frozen, review-gated** lockfile — never against arbitrary PR-introduced packages without dependency review first. |
+
+## 3. AI-agent workflow boundaries
+
+FailSafe's own governance posture *is* the agent-boundary control; this section
+makes the boundaries explicit and auditable.
+
+- **Untrusted input treatment.** PR titles/bodies, issue text, review comments,
+  and commit messages are treated as hostile input. No workflow interpolates
+  that text into a shell context, and no automation derives privileged actions
+  from it.
+- **No AI-authorized side effects without deterministic validation.** No
+  AI-assisted workflow may directly authorize shell execution, deployment,
+  publication, or repository mutation. Every irreversible/outward action passes
+  a deterministic gate first:
+  - **Publish** is gated behind the `production` GitHub Environment (a human
+    reviewer must approve before either marketplace receives a VSIX), and only
+    fires on a `push: tags` event whose tag is verified to be an ancestor of
+    `main`.
+  - **Merge** is gated by the `main` repository ruleset (review + status
+    checks); agent tooling surfaces PRs but does not self-merge.
+  - **Release object creation** runs only after both publish jobs succeed.
+- **Privileged workflows are isolated from untrusted public input.** Privileged
+  jobs (publish, release) trigger on tag pushes, not on `pull_request`, so a
+  fork PR can never enter a context that holds publish secrets. PR-triggered
+  workflows hold only a read-only token.
+
+## 4. Operator settings follow-ups (cannot be set from a PR)
+
+These complete the baseline but are GitHub **settings / ruleset** changes the
+operator must make in the UI — a merged PR alone does not activate them:
+
+1. **Repository default workflow permissions** → Settings → Actions → General →
+   *Workflow permissions* → "Read repository contents and packages
+   permissions" (belt-and-suspenders to the per-workflow blocks).
+2. **`main` ruleset → Require review from Code Owners** — activates
+   `.github/CODEOWNERS` enforcement.
+3. **`main` ruleset → Require status checks** → add **Dependency Review** (and
+   keep the existing checks) to the required set.
+4. **Settings → Actions → General → Fork pull request workflows** → keep
+   "Require approval for all external contributors" so a fork PR cannot run
+   workflows without maintainer approval.
+5. Review **environment secrets** (`VSCE_PAT`, `OVSX_TOKEN`) scope and rotation;
+   confirm the `production` environment retains its required reviewer.
+
+## 5. IOC review
+
+Reviewed for the Shai-Hulud / Mini Shai-Hulud indicators called out in #90.
+**Result: clean** (no matches in the tracked tree at baseline time):
+
+- `setup_bun.js` — not present.
+- `bun_environment.js` — not present.
+- `/tmp/transformers.pyz` — no reference.
+- Unexpected workflow mutations — workflow history reviewed; the only changes
+  are this baseline.
+- Unexpected dependency introductions — none surfaced; the dependency-review
+  gate now guards future PRs.
+
+## 6. Acceptance-criteria mapping (#90)
+
+- Workflow permissions are minimized → §1.
+- Dependency review is enforced → §2.
+- Privileged cache inheritance is blocked → §1 (no privileged cache restore; PR
+  context never reaches privileged jobs).
+- AI-agent workflow boundaries documented and enforced → §3.
+- Deterministic install policy is active → §2 (`npm ci`).
+
+The repository-settings half of "enforced" (ruleset/Code-Owners/required-check
+activation) is itemized in §4 for the operator.


### PR DESCRIPTION
## Summary
Closes #90. Establishes the Tier 1 repository security baseline against Shai-Hulud / Mini Shai-Hulud-class supply-chain attacks — workflow token minimization, SHA-pinned actions, dependency review, frozen installs, CODEOWNERS, and explicit AI-agent action boundaries.

## Workflow security baseline
- **Least-privilege tokens** — every workflow now declares a top-level `permissions:` block. Five are `contents: read`; `release.yml` is `contents: read` with the `github-release` job re-granting `contents: write` per-job; `wiki-init.yml` keeps `contents: write` (it pushes generated wiki content). The publish jobs authenticate via environment secrets (`VSCE_PAT`/`OVSX_TOKEN`), **not** `GITHUB_TOKEN`, so read is sufficient for them — **the publish path is unaffected.**
- **SHA-pinned actions** — every `actions/*` is pinned to a full commit SHA with a `# vX.Y.Z` comment. SHAs were resolved from each action's **current `@v4` tag** (behavior-preserving — no silent major bump to v6/v7/v8).
- **Pin currency** — `.github/dependabot.yml` (github-actions, weekly) keeps the pins from rotting.

## Dependency admission
- `.github/workflows/dependency-review.yml` — runs on every PR to `main`, `fail-on-severity: high`, read-only token (no PR comment → no `pull-requests: write`). Public-repo dependency graph (no GHAS needed).
- `npm ci` (frozen lockfile) is already used across all CI installs.

## AI-agent boundaries + IOC
- `docs/security/SUPPLY_CHAIN_BASELINE.md` — full control inventory, the AI-agent action-boundary posture (no AI-authorized publish/merge/mutation without a deterministic gate; privileged jobs trigger on tag-push only, never on `pull_request`, so fork PRs never reach publish secrets), the **clean IOC review** (`setup_bun.js` / `bun_environment.js` / `transformers.pyz` all absent), and the operator settings follow-ups.
- `.github/CODEOWNERS` gates `.github/`, manifests, and lockfiles.
- `SECURITY.md` points to the baseline.

## ⚠️ Operator settings follow-ups (cannot be set from a PR)
A merged PR alone does not activate these — they are GitHub settings/ruleset actions (itemized in §4 of the baseline doc):
1. Settings → Actions → default workflow permissions → **read-only**.
2. `main` ruleset → **Require review from Code Owners** (activates CODEOWNERS).
3. `main` ruleset → add **Dependency Review** to required status checks.
4. Settings → Actions → **require approval for fork-PR workflows**.
5. Review `production` environment secrets scope/rotation + required reviewer.

## Verification
All 7 workflow YAML files + dependabot.yml parse clean. Permissions inventory verified (6× read, wiki-init write, release per-job write on github-release). No literal secrets in the diff. The publish jobs' trigger (`push: tags`) and auth (env secrets) are untouched — no dead-tag risk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)