### PR TITLE
feat(integrations): read-only Jira issue → intent preview import (#98)

### DIFF
--- a/FailSafe/extension/package.json
+++ b/FailSafe/extension/package.json
@@ -68,7 +68,8 @@
     "onCommand:failsafe.uninstallVoicePack",
     "onCommand:failsafe.substrate.run",
     "onCommand:failsafe.sarif.import",
-    "onCommand:failsafe.mcp.installCatalog"
+    "onCommand:failsafe.mcp.installCatalog",
+    "onCommand:failsafe.jira.import"
   ],
   "main": "./dist/extension/main.js",
   "contributes": {
@@ -125,6 +126,11 @@
       {
         "command": "failsafe.mcp.installCatalog",
         "title": "FailSafe: Install MCP Integration (governed)",
+        "category": "FailSafe"
+      },
+      {
+        "command": "failsafe.jira.import",
+        "title": "FailSafe: Import Jira Issue (preview)",
         "category": "FailSafe"
       },
       {
@@ -310,6 +316,26 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Slack **incoming webhook URL** to post governance notifications to. Treat as a secret — it grants posting to the target channel. Messages are notify-only (no interactive approvals; a link back to the local Command Center is included). Leave empty to disable."
+        },
+        "failsafe.integrations.jira.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable read-only Jira Cloud issue import. The `FailSafe: Import Jira Issue (preview)` command resolves a Jira issue URL/key to an UNCOMMITTED intent preview — nothing is created or synced. Requires base URL + email + API token below."
+        },
+        "failsafe.integrations.jira.baseUrl": {
+          "type": "string",
+          "default": "",
+          "description": "Jira Cloud base URL, e.g. https://your-site.atlassian.net. Leave empty to disable."
+        },
+        "failsafe.integrations.jira.email": {
+          "type": "string",
+          "default": "",
+          "description": "Atlassian account email used for Jira Cloud Basic authentication (paired with the API token below)."
+        },
+        "failsafe.integrations.jira.apiToken": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Jira Cloud **API token** (create at id.atlassian.com → Security → API tokens). Treat as a secret — prefer a token scoped to a read-only account. It is sent only in the `Authorization` header (Basic email:token) and is never logged. Leave empty to disable."
         },
         "failsafe.integrations.openDesign.mcpEnabled": {
           "type": "boolean",

--- a/FailSafe/extension/src/extension/jira-command.ts
+++ b/FailSafe/extension/src/extension/jira-command.ts
@@ -1,0 +1,59 @@
+/**
+ * jira-command — registers `FailSafe: Import Jira Issue (preview)` (#98).
+ * Prompts for a Jira issue URL/key, fetches it read-only via the Jira Cloud
+ * REST API, and shows an UNCOMMITTED intent preview. Nothing is persisted and
+ * no FailSafe intent is created — the operator reviews the preview and decides.
+ * Disabled unless base URL + email + API token are configured. The token is
+ * read from settings and never logged.
+ */
+
+import * as vscode from 'vscode';
+import { fetchJiraIssue, defaultJiraGet } from '../integrations/jira/jira-client';
+
+export function registerJiraImportCommand(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('failsafe.jira.import', async () => {
+      const cfg = vscode.workspace.getConfiguration('failsafe');
+      const enabled = cfg.get<boolean>('integrations.jira.enabled', false);
+      const baseUrl = cfg.get<string>('integrations.jira.baseUrl', '');
+      const email = cfg.get<string>('integrations.jira.email', '');
+      const apiToken = cfg.get<string>('integrations.jira.apiToken', '');
+      if (!enabled || !baseUrl || !email || !apiToken) {
+        vscode.window.showWarningMessage(
+          'Jira import is disabled. Enable `failsafe.integrations.jira.enabled` and set `baseUrl`, `email`, and `apiToken`.',
+        );
+        return;
+      }
+      const input = await vscode.window.showInputBox({
+        title: 'Import Jira issue (preview)',
+        prompt: 'Paste a Jira issue URL or key (e.g. PROJ-123)',
+        ignoreFocusOut: true,
+      });
+      if (!input) return;
+
+      const result = await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Notification, title: 'Fetching Jira issue…' },
+        () => fetchJiraIssue(input, { baseUrl, email, apiToken }, defaultJiraGet),
+      );
+
+      if (!result.ok || !result.preview) {
+        vscode.window.showErrorMessage(`Jira import failed: ${result.error ?? 'unknown error'}`);
+        return;
+      }
+      const p = result.preview;
+      const meta = [
+        p.status && `status: ${p.status}`,
+        p.priority && `priority: ${p.priority}`,
+        p.assignee && `assignee: ${p.assignee}`,
+        p.components.length && `components: ${p.components.join(', ')}`,
+        p.labels.length && `labels: ${p.labels.join(', ')}`,
+        p.sourceUrl && `source: ${p.sourceUrl}`,
+      ].filter(Boolean).join(' · ');
+      // Preview only — explicitly NOT committed.
+      vscode.window.showInformationMessage(
+        `Intent preview (not committed) — ${p.intent}${meta ? `\n${meta}` : ''}`,
+        { modal: false },
+      );
+    }),
+  );
+}

--- a/FailSafe/extension/src/extension/main.ts
+++ b/FailSafe/extension/src/extension/main.ts
@@ -41,6 +41,7 @@ import { bootstrapStartupChecks } from "./bootstrapStartupChecks";
 import { registerSubstrateCommand } from "./substrate-command";
 import { registerSarifImportCommand } from "./sarif-command";
 import { registerMcpInstallCommand } from "./mcp-install-command";
+import { registerJiraImportCommand } from "./jira-command";
 import { SlackNotifier } from "../integrations/slack/SlackNotifier";
 import { defaultRun } from "../qorlogic/PythonInterpreterResolver";
 
@@ -164,6 +165,10 @@ export async function activate(
     // 3.14 Governed MCP install (B-INT-13/14): risk-scored install of catalog
     // MCP integrations (Context7, Mermaid Chart) into .mcp.json.
     registerMcpInstallCommand(context, core.workspaceRoot);
+
+    // 3.14c Jira read-only import (#98): resolve a Jira issue → uncommitted
+    // intent preview. Off-by-default; no network unless configured.
+    registerJiraImportCommand(context);
 
     // 3.15 Slack notify-only (B-INT-9 / #100): post governance enforcement
     // events to a configured incoming webhook. Disabled by default; non-blocking.

--- a/FailSafe/extension/src/integrations/jira/jira-client.ts
+++ b/FailSafe/extension/src/integrations/jira/jira-client.ts
@@ -1,0 +1,99 @@
+/**
+ * jira-client — thin, injectable transport for FailSafe's read-only Jira Cloud
+ * import (#98). Resolves a URL/key → GETs the issue resource → returns an
+ * UNCOMMITTED intent preview. The `get` transport is injected so tests use NO
+ * live network. Auth = Jira Cloud Basic auth (email + API token, base64); the
+ * API token is a SECRET: it is encoded only into the outbound Authorization
+ * header and is NEVER returned in the result or logged. Read-only, non-webhook.
+ */
+
+import * as https from 'https';
+import {
+  parseJiraIssueKey, buildIssuePath, parseIssueResponse, toIntentPreview,
+  type JiraIntentPreview,
+} from './jira-import';
+
+export interface JiraGetFn {
+  (url: string, headers: Record<string, string>):
+    Promise<{ status: number; body: string }>;
+}
+
+export interface JiraAuth {
+  baseUrl?: string;
+  email?: string;
+  apiToken?: string;
+}
+
+export interface JiraFetchResult {
+  ok: boolean;
+  preview?: JiraIntentPreview;
+  status?: number;
+  error?: string;
+}
+
+/** Base64 Basic-auth value for Jira Cloud (email:apiToken). */
+function basicAuth(email: string, apiToken: string): string {
+  return 'Basic ' + Buffer.from(`${email}:${apiToken}`).toString('base64');
+}
+
+/**
+ * Resolve + fetch a Jira issue → uncommitted intent preview. Returns a
+ * structured, non-throwing result. The apiToken never appears in the result.
+ */
+export async function fetchJiraIssue(
+  input: string,
+  auth: JiraAuth,
+  get: JiraGetFn,
+): Promise<JiraFetchResult> {
+  const key = parseJiraIssueKey(input);
+  if (!key) return { ok: false, error: 'Not a Jira issue URL or key (expected e.g. PROJ-123).' };
+  const baseUrl = auth.baseUrl?.trim().replace(/\/$/, '');
+  if (!baseUrl) return { ok: false, error: 'No Jira base URL configured (e.g. https://your-site.atlassian.net).' };
+  if (!auth.email?.trim() || !auth.apiToken?.trim()) {
+    return { ok: false, error: 'No Jira credentials configured (email + API token).' };
+  }
+
+  const url = `${baseUrl}${buildIssuePath(key)}`;
+  try {
+    const res = await get(url, {
+      Accept: 'application/json',
+      Authorization: basicAuth(auth.email.trim(), auth.apiToken.trim()),
+      'User-Agent': 'FailSafe',
+    });
+    if (res.status === 429) return { ok: false, status: 429, error: 'Jira rate limit reached (HTTP 429).' };
+    if (res.status === 401 || res.status === 403) {
+      return { ok: false, status: res.status, error: 'Jira auth failed — check the email / API token / permissions.' };
+    }
+    if (res.status === 404) return { ok: false, status: 404, error: `Issue ${key} not found (or no access).` };
+    if (res.status < 200 || res.status >= 300) return { ok: false, status: res.status, error: `Jira returned HTTP ${res.status}.` };
+
+    let json: unknown;
+    try { json = JSON.parse(res.body); } catch { return { ok: false, error: 'Invalid JSON from Jira.' }; }
+    const issue = parseIssueResponse(json);
+    if (!issue) return { ok: false, error: `Issue ${key} not found (or no access).` };
+    return { ok: true, preview: toIntentPreview(issue, baseUrl) };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
+
+/** Default https transport (used in production; tests inject their own). */
+export const defaultJiraGet: JiraGetFn = (url, headers) =>
+  new Promise((resolve, reject) => {
+    try {
+      const u = new URL(url);
+      const req = https.request(
+        { hostname: u.hostname, path: u.pathname + u.search, method: 'GET', headers, timeout: 8000 },
+        (res) => {
+          const chunks: Buffer[] = [];
+          res.on('data', (c) => chunks.push(c as Buffer));
+          res.on('end', () => resolve({ status: res.statusCode ?? 0, body: Buffer.concat(chunks).toString('utf8') }));
+        },
+      );
+      req.on('timeout', () => req.destroy(new Error('timeout')));
+      req.on('error', reject);
+      req.end();
+    } catch (e) {
+      reject(e instanceof Error ? e : new Error(String(e)));
+    }
+  });

--- a/FailSafe/extension/src/integrations/jira/jira-import.ts
+++ b/FailSafe/extension/src/integrations/jira/jira-import.ts
@@ -1,0 +1,155 @@
+/**
+ * jira-import — pure logic for FailSafe's read-only Jira Cloud issue → intent
+ * preview import (#98, v1). Mirrors the Linear import shape. READ-ONLY: resolve
+ * a Jira issue URL or bare key → fetch the canonical fields → present an
+ * UNCOMMITTED intent preview. NO mutation, NO webhooks (phase two). The API
+ * token is a secret handled only by the injectable transport (jira-client.ts);
+ * none of these pure functions ever see or carry it.
+ *
+ * Uses the Jira Cloud REST v2 issue resource (description returned as a string,
+ * not ADF) so the preview is a plain summary. Defensive field access: tolerates
+ * missing/null fields and ignores unknown custom fields (no schema assumption).
+ */
+
+/** A Jira issue key is PROJECTKEY-NUMBER, e.g. PROJ-123 / AB1-7. */
+const KEY_RE = /\b([A-Z][A-Z0-9]+-\d+)\b/;
+
+/**
+ * Resolve a Jira issue URL or a bare key to the canonical issue key.
+ *   https://site.atlassian.net/browse/PROJ-123        → PROJ-123
+ *   https://site.atlassian.net/browse/PROJ-123?x=1     → PROJ-123
+ *   PROJ-123                                           → PROJ-123
+ * Returns null for anything without a valid key (rejects garbage).
+ */
+export function parseJiraIssueKey(input: string): string | null {
+  if (typeof input !== 'string') return null;
+  const s = input.trim();
+  if (!s) return null;
+  // URL form: pull the segment after /browse/.
+  const urlMatch = /\/browse\/([A-Za-z][A-Za-z0-9]+-\d+)(?:[/?#]|$)/.exec(s);
+  if (urlMatch) return urlMatch[1].toUpperCase();
+  // Bare key (must be the whole token, not embedded in prose noise).
+  const m = KEY_RE.exec(s.toUpperCase());
+  if (m && /^[A-Za-z0-9-]+$/.test(s)) return m[1].toUpperCase();
+  return null;
+}
+
+/** Canonical fields v1 reads, requested explicitly to keep the payload small. */
+export const JIRA_ISSUE_FIELDS = ['summary', 'description', 'status', 'priority', 'assignee', 'labels', 'components'] as const;
+
+/** Pure builder for the issue REST path (v2 → string description). */
+export function buildIssuePath(key: string): string {
+  return `/rest/api/2/issue/${encodeURIComponent(key)}?fields=${JIRA_ISSUE_FIELDS.join(',')}`;
+}
+
+export interface CanonicalJiraIssue {
+  key: string;
+  summary: string;
+  description?: string;
+  status?: string;
+  priority?: string;
+  assignee?: string;
+  labels: string[];
+  components: string[];
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim() ? v : undefined;
+}
+
+/** Best-effort plain text from a description that may be a string (v2) or, if a
+ *  caller pointed at v3, an ADF document object. Returns undefined when neither. */
+function descriptionText(v: unknown): string | undefined {
+  const s = str(v);
+  if (s) return s;
+  // ADF fallback: walk `content[].content[].text` defensively.
+  if (v && typeof v === 'object') {
+    const parts: string[] = [];
+    const walk = (node: unknown): void => {
+      if (!node || typeof node !== 'object') return;
+      const n = node as Record<string, unknown>;
+      const t = str(n.text);
+      if (t) parts.push(t);
+      if (Array.isArray(n.content)) n.content.forEach(walk);
+    };
+    walk(v);
+    const joined = parts.join(' ').trim();
+    return joined || undefined;
+  }
+  return undefined;
+}
+
+/**
+ * Defensive parse of a Jira issue response → CanonicalJiraIssue. Tolerates
+ * missing/null relations and ignores unknown custom fields. Returns null when
+ * there is no issue (404 / error body). Never reads beyond the canonical
+ * fields, so no token could leak through.
+ */
+export function parseIssueResponse(json: unknown): CanonicalJiraIssue | null {
+  const root = (json && typeof json === 'object') ? (json as Record<string, unknown>) : null;
+  if (!root) return null;
+  const key = str(root.key);
+  if (!key) return null;
+  const fields = root.fields && typeof root.fields === 'object' ? (root.fields as Record<string, unknown>) : {};
+
+  const status = fields.status && typeof fields.status === 'object' ? (fields.status as Record<string, unknown>) : null;
+  const priority = fields.priority && typeof fields.priority === 'object' ? (fields.priority as Record<string, unknown>) : null;
+  const assignee = fields.assignee && typeof fields.assignee === 'object' ? (fields.assignee as Record<string, unknown>) : null;
+
+  const labels = Array.isArray(fields.labels)
+    ? (fields.labels as unknown[]).map(str).filter((l): l is string => !!l)
+    : [];
+  const components = Array.isArray(fields.components)
+    ? (fields.components as unknown[])
+        .map((c) => (c && typeof c === 'object' ? str((c as Record<string, unknown>).name) : undefined))
+        .filter((c): c is string => !!c)
+    : [];
+
+  return {
+    key,
+    summary: str(fields.summary) ?? '(no summary)',
+    description: descriptionText(fields.description),
+    status: status ? str(status.name) : undefined,
+    priority: priority ? str(priority.name) : undefined,
+    assignee: assignee ? (str(assignee.displayName) ?? str(assignee.name)) : undefined,
+    labels,
+    components,
+  };
+}
+
+export interface JiraIntentPreview {
+  source: 'jira';
+  /** UNCOMMITTED: shown to the operator; nothing is persisted. */
+  committed: false;
+  key: string;
+  summary: string;
+  /** A concise intent line derived from the issue (no raw secrets, by construction). */
+  intent: string;
+  /** The human browse URL for the issue (acceptance: preview shows source URL). */
+  sourceUrl?: string;
+  description?: string;
+  status?: string;
+  priority?: string;
+  assignee?: string;
+  labels: string[];
+  components: string[];
+}
+
+/** Pure mapper: canonical issue → an UNCOMMITTED FailSafe intent preview. */
+export function toIntentPreview(issue: CanonicalJiraIssue, baseUrl?: string): JiraIntentPreview {
+  const base = baseUrl ? baseUrl.replace(/\/$/, '') : undefined;
+  return {
+    source: 'jira',
+    committed: false,
+    key: issue.key,
+    summary: issue.summary,
+    intent: [issue.key, issue.summary].filter(Boolean).join(' — '),
+    sourceUrl: base ? `${base}/browse/${issue.key}` : undefined,
+    description: issue.description,
+    status: issue.status,
+    priority: issue.priority,
+    assignee: issue.assignee,
+    labels: issue.labels,
+    components: issue.components,
+  };
+}

--- a/FailSafe/extension/src/test/integrations/jira/jira.test.ts
+++ b/FailSafe/extension/src/test/integrations/jira/jira.test.ts
@@ -1,0 +1,114 @@
+import { strict as assert } from 'assert';
+import {
+  parseJiraIssueKey, buildIssuePath, parseIssueResponse, toIntentPreview,
+} from '../../../integrations/jira/jira-import';
+import { fetchJiraIssue, type JiraGetFn } from '../../../integrations/jira/jira-client';
+
+suite('jira-import parse (#98)', () => {
+  test('resolves a Jira issue URL (with + without query) and a bare key, case-normalized', () => {
+    assert.equal(parseJiraIssueKey('https://acme.atlassian.net/browse/PROJ-123'), 'PROJ-123');
+    assert.equal(parseJiraIssueKey('https://acme.atlassian.net/browse/PROJ-123?focusedCommentId=1'), 'PROJ-123');
+    assert.equal(parseJiraIssueKey('PROJ-123'), 'PROJ-123');
+    assert.equal(parseJiraIssueKey('proj-123'), 'PROJ-123');
+  });
+  test('rejects garbage', () => {
+    assert.equal(parseJiraIssueKey('not an issue'), null);
+    assert.equal(parseJiraIssueKey('https://example.com/whatever'), null);
+    assert.equal(parseJiraIssueKey(''), null);
+  });
+});
+
+suite('jira-import path + parse + map (#98)', () => {
+  test('buildIssuePath targets the v2 issue resource with explicit fields', () => {
+    const path = buildIssuePath('PROJ-7');
+    assert.match(path, /^\/rest\/api\/2\/issue\/PROJ-7\?fields=/);
+    assert.match(path, /summary,description,status,priority,assignee,labels,components/);
+  });
+
+  test('parseIssueResponse tolerates missing fields + ignores custom fields; null when no issue', () => {
+    const full = parseIssueResponse({ key: 'PROJ-1', fields: {
+      summary: 'Fix login', description: 'Steps to repro', status: { name: 'In Progress' },
+      priority: { name: 'High' }, assignee: { displayName: 'Ada Lovelace' },
+      labels: ['bug', 'p1'], components: [{ name: 'auth' }, { name: 'api' }],
+      customfield_10010: { weird: true }, // unknown custom field — must be ignored
+    } });
+    assert.equal(full?.summary, 'Fix login');
+    assert.equal(full?.status, 'In Progress');
+    assert.equal(full?.priority, 'High');
+    assert.equal(full?.assignee, 'Ada Lovelace');
+    assert.deepEqual(full?.labels, ['bug', 'p1']);
+    assert.deepEqual(full?.components, ['auth', 'api']);
+
+    const sparse = parseIssueResponse({ key: 'PROJ-2', fields: { summary: 'X', assignee: null, status: null, labels: null, components: null } });
+    assert.equal(sparse?.assignee, undefined);
+    assert.deepEqual(sparse?.labels, []);
+    assert.deepEqual(sparse?.components, []);
+
+    // ADF description object (v3 shape) → plain text fallback
+    const adf = parseIssueResponse({ key: 'PROJ-3', fields: { summary: 'Y',
+      description: { type: 'doc', content: [{ type: 'paragraph', content: [{ type: 'text', text: 'hello' }, { type: 'text', text: 'world' }] }] } } });
+    assert.equal(adf?.description, 'hello world');
+
+    assert.equal(parseIssueResponse({ errorMessages: ['Issue does not exist'] }), null);
+    assert.equal(parseIssueResponse(null), null);
+  });
+
+  test('toIntentPreview builds an UNCOMMITTED preview with a source URL', () => {
+    const p = toIntentPreview({ key: 'PROJ-1', summary: 'Fix login', labels: ['bug'], components: [] }, 'https://acme.atlassian.net');
+    assert.equal(p.committed, false);
+    assert.equal(p.source, 'jira');
+    assert.match(p.intent, /PROJ-1 — Fix login/);
+    assert.equal(p.sourceUrl, 'https://acme.atlassian.net/browse/PROJ-1');
+  });
+});
+
+suite('jira-client (#98)', () => {
+  const baseUrl = 'https://acme.atlassian.net';
+  const issueBody = JSON.stringify({ key: 'PROJ-1', fields: { summary: 'Fix login', status: { name: 'To Do' }, labels: [], components: [] } });
+  const auth = { baseUrl, email: 'dev@acme.com', apiToken: 'jira_TOPSECRET' };
+
+  test('parse failure short-circuits before any network call', async () => {
+    let called = false;
+    const get: JiraGetFn = async () => { called = true; return { status: 200, body: issueBody }; };
+    const r = await fetchJiraIssue('garbage', auth, get);
+    assert.equal(r.ok, false); assert.equal(called, false);
+  });
+
+  test('missing baseUrl / credentials → error, no network', async () => {
+    let called = false;
+    const get: JiraGetFn = async () => { called = true; return { status: 200, body: issueBody }; };
+    const noBase = await fetchJiraIssue('PROJ-1', { email: 'x', apiToken: 'y' }, get);
+    assert.equal(noBase.ok, false); assert.equal(called, false);
+    const noCreds = await fetchJiraIssue('PROJ-1', { baseUrl, email: '', apiToken: '' }, get);
+    assert.equal(noCreds.ok, false); assert.equal(called, false);
+  });
+
+  test('happy path → uncommitted preview with source URL', async () => {
+    const get: JiraGetFn = async (url) => { assert.match(url, /\/rest\/api\/2\/issue\/PROJ-1\?fields=/); return { status: 200, body: issueBody }; };
+    const r = await fetchJiraIssue('https://acme.atlassian.net/browse/PROJ-1', auth, get);
+    assert.equal(r.ok, true);
+    assert.equal(r.preview?.committed, false);
+    assert.equal(r.preview?.sourceUrl, 'https://acme.atlassian.net/browse/PROJ-1');
+  });
+
+  test('SECRET MASKING: the api token (and its base64) is sent only in the Authorization header, never in the result', async () => {
+    let sentAuth: string | undefined;
+    const get: JiraGetFn = async (_u, headers) => { sentAuth = headers.Authorization; return { status: 200, body: issueBody }; };
+    const r = await fetchJiraIssue('PROJ-1', auth, get);
+    assert.ok(sentAuth?.startsWith('Basic '), 'Basic auth header is sent');
+    const b64 = Buffer.from('dev@acme.com:jira_TOPSECRET').toString('base64');
+    assert.equal(sentAuth, `Basic ${b64}`, 'header is base64(email:token)');
+    const s = JSON.stringify(r);
+    assert.ok(!s.includes('jira_TOPSECRET'), 'raw token never appears in the result');
+    assert.ok(!s.includes(b64), 'base64 credential never appears in the result');
+  });
+
+  test('401/403 → auth error; 404 → not found; 429 → rate limit (non-throwing)', async () => {
+    const r401 = await fetchJiraIssue('PROJ-1', auth, async () => ({ status: 401, body: '' }));
+    assert.equal(r401.ok, false); assert.match(r401.error ?? '', /auth/i);
+    const r404 = await fetchJiraIssue('PROJ-1', auth, async () => ({ status: 404, body: '' }));
+    assert.equal(r404.ok, false); assert.equal(r404.status, 404);
+    const r429 = await fetchJiraIssue('PROJ-1', auth, async () => ({ status: 429, body: '' }));
+    assert.equal(r429.ok, false); assert.equal(r429.status, 429);
+  });
+});


### PR DESCRIPTION
## Summary
Closes #98 (read path; first safe slice). Resolve a Jira Cloud issue **URL** (`https://site.atlassian.net/browse/PROJ-123`) or a **bare key** (`PROJ-123`) → fetch the canonical fields via the Jira REST API → present an **UNCOMMITTED intent preview**. Nothing is created, mutated, or synced; no FailSafe intent is committed without the operator. Mirrors the established Linear/Slack/GitHub integration shape (pure logic + injectable transport, off by default, secret masked, defensive field access).

## What's in it
- **Pure logic** (`jira-import.ts`): `parseJiraIssueKey` (URL `/browse/` + bare, case-normalized, rejects garbage), `buildIssuePath` (v2 issue resource with an explicit field list), defensive `parseIssueResponse` (tolerates missing/null, **ignores unknown custom fields** — no schema assumption; ADF description object → plain-text fallback), `toIntentPreview` (`committed: false`, includes the browse **source URL**).
- **Injectable transport** (`jira-client.ts`): `fetchJiraIssue` (parse → short-circuit before any network on bad input / missing base URL / missing creds → GET with Basic auth → 401/403/404/429/non-2xx handling → preview), `defaultJiraGet` https transport.
- **Command**: `FailSafe: Import Jira Issue (preview)`.
- **Config**: `failsafe.integrations.jira.{enabled (false), baseUrl, email, apiToken (secret)}`.

## Acceptance criteria → coverage
- Issue import handles custom fields without assuming one schema → defensive parse ignores `customfield_*`; test asserts it. ✅
- Intent preview shows source URL + imported fields → `sourceUrl` + status/priority/assignee/labels/components in the preview. ✅
- Webhook registration opt-in + documents permissions → **deferred to phase two** (read path lands first, per the issue's "first safe slice"). ✅ (noted)
- Tests cover issue import, missing field, no-auth → plus secret masking + 404/429. ✅

## Secret handling
The API token is encoded only into the Basic `Authorization` header. A masking test asserts **neither the raw token nor its base64** appears anywhere in `JSON.stringify(result)`.

## Notes
Uses the Jira Cloud REST **v2** issue resource so `description` returns as a string (the preview stays a plain summary); a v3/ADF description object is still handled via a defensive plain-text walk. Full `test:all` runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)