### PR TITLE
fix(test): de-flake FX801 IdleScheduler timing tests

### DIFF
--- a/FailSafe/extension/src/test/integrations/mcp/idle-scheduler.test.ts
+++ b/FailSafe/extension/src/test/integrations/mcp/idle-scheduler.test.ts
@@ -1,19 +1,32 @@
 // FX801 — Consolidated idle-scheduler (6 cases).
 // Moved from src/integrations/{bicameral,open-design}/idle-scheduler.ts by B-INT-4.
+//
+// De-flaked: the positive ("should fire") cases previously armed a ~30ms timer
+// then asserted after a fixed `sleep(60)`. Under a loaded CI runner (multiple
+// test:all jobs competing for CPU) the fixed sleep could resolve before the
+// idle callback ran — and IdleScheduler.checkIdle() re-arms when
+// `Date.now() - lastActivityAt < idleMs` (sub-ms jitter), pushing the real fire
+// past the 60ms window. Both produced a nondeterministic `0 !== 1`. The fix is
+// to poll the observable (`fired`) until it reaches the expected value with a
+// generous timeout instead of asserting after one fixed sleep. The negative
+// ("must not fire") cases keep a bounded wait: a load-delayed timer can only
+// fire LATER, so a fixed wait cannot turn a correct no-fire into a false red.
 
 import { strict as assert } from 'assert';
 import { IdleScheduler, DEFAULT_IDLE_DISCONNECT_MS } from '../../../integrations/mcp/idle-scheduler';
 
-function withFakeTimers<T>(fn: () => Promise<T>): Promise<T> {
-  // Minimal manual time advance: tests below all use fixed idleMs values and
-  // explicitly drive `Date.now()` via no monkey-patching — they instead rely
-  // on small idleMs (e.g. 30ms) and real setTimeout. Wrapper retained for
-  // future fake-timer migration.
-  return fn();
-}
-
 function sleep(ms: number): Promise<void> {
   return new Promise((res) => setTimeout(res, ms));
+}
+
+/** Poll `predicate` until true or `timeoutMs` elapses. Deterministic under load:
+ *  a slow runner just polls a few more times rather than failing a fixed wait. */
+async function waitFor(predicate: () => boolean, timeoutMs = 2000, intervalMs = 5): Promise<void> {
+  const start = Date.now();
+  while (!predicate()) {
+    if (Date.now() - start > timeoutMs) return; // give up; caller makes the assertion
+    await sleep(intervalMs);
+  }
 }
 
 suite('FX801 — IdleScheduler (consolidated)', () => {
@@ -21,50 +34,50 @@ suite('FX801 — IdleScheduler (consolidated)', () => {
     assert.equal(DEFAULT_IDLE_DISCONNECT_MS, 900_000);
   });
 
-  test('case 2: timer fires onIdle at idleMs when no calls inflight', async () => withFakeTimers(async () => {
+  test('case 2: timer fires onIdle at idleMs when no calls inflight', async () => {
     let fired = 0;
     const sched = new IdleScheduler({ idleMs: 30, onIdle: () => { fired++; } });
     // Schedule by ending a (zero-call) interval.
     sched.endCall(); // first endCall arms the timer with lastActivityAt = now
-    await sleep(60);
+    await waitFor(() => fired >= 1);
     assert.equal(fired, 1);
     sched.dispose();
-  }));
+  });
 
-  test('case 3: beginCall suppresses fire while inflight; endCall resets activity timestamp at end-of-call', async () => withFakeTimers(async () => {
+  test('case 3: beginCall suppresses fire while inflight; endCall resets activity timestamp at end-of-call', async () => {
     let fired = 0;
     const sched = new IdleScheduler({ idleMs: 40, onIdle: () => { fired++; } });
     sched.beginCall();
     sched.endCall();   // arms timer
     sched.beginCall(); // suppresses while inflight
-    await sleep(60);
+    await sleep(120);  // > 2 idle windows: if it were going to fire while inflight, it would have
     assert.equal(fired, 0, 'should not fire while inflight');
     sched.endCall();   // re-arms with lastActivityAt = now
-    await sleep(60);
+    await waitFor(() => fired >= 1);
     assert.equal(fired, 1, 'should fire after inflight resolves and idle window elapses');
     sched.dispose();
-  }));
+  });
 
-  test('case 4: cancel() is idempotent and stops a pending fire', async () => withFakeTimers(async () => {
+  test('case 4: cancel() is idempotent and stops a pending fire', async () => {
     let fired = 0;
     const sched = new IdleScheduler({ idleMs: 30, onIdle: () => { fired++; } });
     sched.endCall();
     sched.cancel();
     sched.cancel(); // idempotent
-    await sleep(60);
+    await sleep(120); // > 3 idle windows: a cancelled timer must never fire
     assert.equal(fired, 0);
     sched.dispose();
-  }));
+  });
 
-  test('case 5: idleMs: 0 disables scheduling entirely', async () => withFakeTimers(async () => {
+  test('case 5: idleMs: 0 disables scheduling entirely', async () => {
     let fired = 0;
     const sched = new IdleScheduler({ idleMs: 0, onIdle: () => { fired++; } });
     sched.endCall();
     sched.endCall();
-    await sleep(40);
+    await sleep(80); // disabled scheduler must never fire
     assert.equal(fired, 0);
     sched.dispose();
-  }));
+  });
 
   test('case 6: inflight count never goes negative under racing endCall', () => {
     let fired = 0;


### PR DESCRIPTION
## Summary
De-flakes the `FX801 — IdleScheduler` suite, the timing test that intermittently fails `test:all` (and has been a dead-tag hazard on the release pipeline). **No production code changes** — only the test's timing assertions.

## Root cause
The positive ("should fire") cases armed a ~30 ms idle timer then asserted after a fixed `sleep(60)`. Under a loaded CI runner (multiple `test:all` jobs competing for CPU) that raced two ways:
1. **Event-loop starvation** delayed the `onIdle` callback past the 60 ms window.
2. `IdleScheduler.checkIdle()` **re-arms** when `Date.now() - lastActivityAt < idleMs` (sub-millisecond jitter), pushing the real fire into a *second* idle window.

Both surfaced as a nondeterministic `0 !== 1` — observed failing on **case 2** and **case 3** across separate runs this week.

## Fix
- Positive cases now **poll the observable** (`fired`) until the expected value with a generous timeout (`waitFor`, 2 s cap) instead of asserting after one fixed sleep. A slow runner just polls a few more times.
- Negative ("must not fire") cases keep a **bounded fixed wait** — a load-delayed timer can only fire *later*, so a fixed wait cannot turn a correct no-fire into a false red.
- Removed the misleading no-op `withFakeTimers` wrapper.

## Verification
Compiled the scheduler and ran all six cases **25 iterations under sustained artificial CPU load** (an 8 ms-per-tick burn loop simulating a starved runner): **25/25 all-green**. The previous fixed-sleep version fails several iterations under the same load. tsc 0 errors, eslint clean.

Closes the tracked "de-flake idle-scheduler.test.js" follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)