### PR TITLE
feat(integrations): governed CLI agent wrappers — Continue + Aider (#104, #107)

### DIFF
--- a/FailSafe/extension/package.json
+++ b/FailSafe/extension/package.json
@@ -68,7 +68,9 @@
     "onCommand:failsafe.uninstallVoicePack",
     "onCommand:failsafe.substrate.run",
     "onCommand:failsafe.sarif.import",
-    "onCommand:failsafe.mcp.installCatalog"
+    "onCommand:failsafe.mcp.installCatalog",
+    "onCommand:failsafe.continue.run",
+    "onCommand:failsafe.aider.run"
   ],
   "main": "./dist/extension/main.js",
   "contributes": {
@@ -125,6 +127,16 @@
       {
         "command": "failsafe.mcp.installCatalog",
         "title": "FailSafe: Install MCP Integration (governed)",
+        "category": "FailSafe"
+      },
+      {
+        "command": "failsafe.continue.run",
+        "title": "FailSafe: Run Continue (governed)",
+        "category": "FailSafe"
+      },
+      {
+        "command": "failsafe.aider.run",
+        "title": "FailSafe: Run Aider (governed)",
         "category": "FailSafe"
       },
       {
@@ -310,6 +322,47 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Slack **incoming webhook URL** to post governance notifications to. Treat as a secret — it grants posting to the target channel. Messages are notify-only (no interactive approvals; a link back to the local Command Center is included). Leave empty to disable."
+        },
+        "failsafe.integrations.continue.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable the governed Continue (`cn`) headless wrapper. The `FailSafe: Run Continue (governed)` command runs a prompt through Continue with a restricted tool allowlist, classifies the produced diff, and routes L3-risk changes to the L3 approval queue. Spawns argv-form (no shell). No network unless you run the command."
+        },
+        "failsafe.integrations.continue.apiKey": {
+          "type": "string",
+          "default": "",
+          "markdownDescription": "Continue API key (`CONTINUE_API_KEY`). Treat as a secret — it is passed to the `cn` child process via the environment only, never in the command line or any receipt, and is never logged. Leave empty if `cn` is already authenticated."
+        },
+        "failsafe.integrations.continue.allow": {
+          "type": "array",
+          "items": { "type": "string" },
+          "default": [],
+          "description": "Explicit Continue tool allowlist (passed as repeated `--allow <tool>`). Shell/exec tools map to risk tier L3, file-write tools to L2, read-only to L1. An L3 allowlist is escalated to L3 approval BEFORE the agent runs."
+        },
+        "failsafe.integrations.continue.allowWrites": {
+          "type": "boolean",
+          "default": false,
+          "description": "Permit Continue runs whose risk tier is below L3 to proceed without escalation. When false, any write-tier request is blocked. L3 always escalates regardless."
+        },
+        "failsafe.integrations.aider.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable the governed Aider wrapper. The `FailSafe: Run Aider (governed)` command runs Aider with auto-commit OFF, captures the resulting (uncommitted) diff, and routes L3-risk changes to the L3 approval queue. Spawns argv-form (no shell)."
+        },
+        "failsafe.integrations.aider.allowDirty": {
+          "type": "boolean",
+          "default": false,
+          "description": "Allow running Aider against a worktree that already has uncommitted changes. When false (default), a dirty worktree is refused so the captured diff is unambiguously Aider's."
+        },
+        "failsafe.integrations.aider.autoCommit": {
+          "type": "boolean",
+          "default": false,
+          "description": "Let Aider auto-commit its changes (`--auto-commits`). Off by default (`--no-auto-commits`) so changes stay uncommitted for the diff gate."
+        },
+        "failsafe.integrations.aider.allowWrites": {
+          "type": "boolean",
+          "default": false,
+          "description": "Permit Aider runs whose diff risk tier is below L3 to proceed without escalation. When false, sub-L3 changes are blocked. L3 always escalates regardless."
         },
         "failsafe.integrations.openDesign.mcpEnabled": {
           "type": "boolean",

--- a/FailSafe/extension/src/extension/agent-cli-command.ts
+++ b/FailSafe/extension/src/extension/agent-cli-command.ts
@@ -1,0 +1,107 @@
+/**
+ * agent-cli-command — registers the Group B governed CLI-agent commands:
+ *   `FailSafe: Run Continue (governed)`  (#104)
+ *   `FailSafe: Run Aider (governed)`     (#107)
+ *
+ * Each gathers config + a prompt, runs the agent through the unit-tested
+ * wrapper (argv-form, secrets in env only), then acts on the gate decision:
+ * ALLOW → report the captured diff; BLOCK → warn; ESCALATE → enqueue a real L3
+ * approval via QorLogicManager. Risk is classified with the live PolicyEngine.
+ * Off-by-default; the API key/secret is read from settings and never logged.
+ */
+
+import * as vscode from 'vscode';
+import type { RiskGrade } from '../shared/types/risk';
+import { defaultAgentRun, type AgentRunOutcome } from '../integrations/agent-cli/agent-cli-core';
+import { runContinueGoverned } from '../integrations/agent-cli/continue-wrapper';
+import { runAiderGoverned } from '../integrations/agent-cli/aider-wrapper';
+
+interface PolicyClassifier { classifyRisk(filePath: string, content?: string): RiskGrade }
+interface L3Queue {
+  queueL3Approval(request: {
+    filePath: string; riskGrade: RiskGrade; agentDid: string; agentTrust: number;
+    sentinelSummary: string; flags: string[]; kind?: string; meta?: Record<string, unknown>;
+  }): Promise<string>;
+}
+
+export interface AgentCliDeps {
+  workspaceRoot: string;
+  policyEngine: PolicyClassifier;
+  qorelogicManager: L3Queue;
+}
+
+async function escalate(deps: AgentCliDeps, agent: string, out: AgentRunOutcome): Promise<void> {
+  const filePath = out.diff?.paths[0] ?? `<${agent}-run>`;
+  await deps.qorelogicManager.queueL3Approval({
+    filePath,
+    riskGrade: 'L3',
+    agentDid: `did:failsafe:agent:${agent}`,
+    agentTrust: 0.5,
+    sentinelSummary: `${agent} CLI produced an L3-risk change (${out.diff?.files ?? 0} file(s), +${out.diff?.additions ?? 0}/-${out.diff?.deletions ?? 0}). ${out.decision?.reason ?? ''}`.trim(),
+    flags: ['cli-agent', agent],
+    kind: 'cli-agent-run',
+    meta: { receipt: out.receipt },
+  });
+}
+
+async function report(deps: AgentCliDeps, agent: string, out: AgentRunOutcome): Promise<void> {
+  if (!out.available) { vscode.window.showWarningMessage(`${out.error ?? `${agent} not available`}.`); return; }
+  const d = out.decision;
+  if (d?.verdict === 'ESCALATE') {
+    await escalate(deps, agent, out);
+    vscode.window.showWarningMessage(`${agent}: L3-risk change — escalated to the L3 approval queue (${out.diff?.files ?? 0} file(s), uncommitted).`);
+  } else if (d?.verdict === 'BLOCK') {
+    vscode.window.showWarningMessage(`${agent}: ${d.reason}.`);
+  } else if (d?.verdict === 'ALLOW') {
+    vscode.window.showInformationMessage(`${agent}: ran (auto-approve tier). Captured diff: ${out.diff?.files ?? 0} file(s), +${out.diff?.additions ?? 0}/-${out.diff?.deletions ?? 0}. Review before committing.`);
+  } else {
+    vscode.window.showWarningMessage(`${agent}: no decision produced.`);
+  }
+}
+
+export function registerAgentCliCommands(context: vscode.ExtensionContext, deps: AgentCliDeps): void {
+  const classify = (p: string): RiskGrade => deps.policyEngine.classifyRisk(p);
+  const cwd = deps.workspaceRoot;
+
+  context.subscriptions.push(
+    vscode.commands.registerCommand('failsafe.continue.run', async () => {
+      const cfg = vscode.workspace.getConfiguration('failsafe');
+      const enabled = cfg.get<boolean>('integrations.continue.enabled', false);
+      const apiKey = cfg.get<string>('integrations.continue.apiKey', '');
+      if (!enabled) { vscode.window.showWarningMessage('Continue integration is disabled. Enable `failsafe.integrations.continue.enabled`.'); return; }
+      const prompt = await vscode.window.showInputBox({ title: 'Run Continue (governed)', prompt: 'Prompt for the Continue headless agent', ignoreFocusOut: true });
+      if (!prompt) return;
+      const allow = cfg.get<string[]>('integrations.continue.allow', []) ?? [];
+      const writesAllowed = cfg.get<boolean>('integrations.continue.allowWrites', false);
+      const out = await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Notification, title: 'Running Continue (governed)…' },
+        () => runContinueGoverned(
+          { prompt, allow, apiKey: apiKey || undefined, cwd, writesAllowed, baseEnv: process.env },
+          { run: defaultAgentRun, classify, issuedAt: new Date().toISOString() },
+        ),
+      );
+      await report(deps, 'continue', out);
+    }),
+
+    vscode.commands.registerCommand('failsafe.aider.run', async () => {
+      const cfg = vscode.workspace.getConfiguration('failsafe');
+      const enabled = cfg.get<boolean>('integrations.aider.enabled', false);
+      if (!enabled) { vscode.window.showWarningMessage('Aider integration is disabled. Enable `failsafe.integrations.aider.enabled`.'); return; }
+      const prompt = await vscode.window.showInputBox({ title: 'Run Aider (governed)', prompt: 'Message for Aider (one-shot)', ignoreFocusOut: true });
+      if (!prompt) return;
+      const out = await vscode.window.withProgress(
+        { location: vscode.ProgressLocation.Notification, title: 'Running Aider (governed)…' },
+        () => runAiderGoverned(
+          {
+            prompt, cwd,
+            allowDirty: cfg.get<boolean>('integrations.aider.allowDirty', false),
+            autoCommit: cfg.get<boolean>('integrations.aider.autoCommit', false),
+            writesAllowed: cfg.get<boolean>('integrations.aider.allowWrites', false),
+          },
+          { run: defaultAgentRun, classify, issuedAt: new Date().toISOString() },
+        ),
+      );
+      await report(deps, 'aider', out);
+    }),
+  );
+}

--- a/FailSafe/extension/src/extension/main.ts
+++ b/FailSafe/extension/src/extension/main.ts
@@ -41,6 +41,7 @@ import { bootstrapStartupChecks } from "./bootstrapStartupChecks";
 import { registerSubstrateCommand } from "./substrate-command";
 import { registerSarifImportCommand } from "./sarif-command";
 import { registerMcpInstallCommand } from "./mcp-install-command";
+import { registerAgentCliCommands } from "./agent-cli-command";
 import { SlackNotifier } from "../integrations/slack/SlackNotifier";
 import { defaultRun } from "../qorlogic/PythonInterpreterResolver";
 
@@ -164,6 +165,15 @@ export async function activate(
     // 3.14 Governed MCP install (B-INT-13/14): risk-scored install of catalog
     // MCP integrations (Context7, Mermaid Chart) into .mcp.json.
     registerMcpInstallCommand(context, core.workspaceRoot);
+
+    // 3.14d Governed CLI agent wrappers (Group B — #104 Continue, #107 Aider):
+    // run a headless coding-agent CLI argv-form, classify the produced diff with
+    // the live PolicyEngine, and route L3-risk changes to the L3 queue.
+    registerAgentCliCommands(context, {
+      workspaceRoot: core.workspaceRoot,
+      policyEngine: qor.policyEngine,
+      qorelogicManager: qor.qorelogicManager,
+    });
 
     // 3.15 Slack notify-only (B-INT-9 / #100): post governance enforcement
     // events to a configured incoming webhook. Disabled by default; non-blocking.

--- a/FailSafe/extension/src/integrations/agent-cli/agent-cli-core.ts
+++ b/FailSafe/extension/src/integrations/agent-cli/agent-cli-core.ts
@@ -1,0 +1,189 @@
+/**
+ * agent-cli-core — shared substrate for FailSafe's CLI agent-wrapper integrations
+ * (Group B: Continue #104, Aider #107). Governs a headless coding-agent CLI by
+ * (1) detecting the binary, (2) classifying the risk of the diff it produces,
+ * (3) deciding ALLOW / BLOCK / ESCALATE-to-L3, and (4) emitting a receipt.
+ *
+ * Everything here is pure given an injected runner (`AgentRunFn`), so no live
+ * process is spawned in tests. argv-form ONLY — the runner spawns with
+ * `shell: false`; command strings are never constructed (no shell-injection
+ * surface). Secrets (API keys) travel via the child ENV, never argv and never
+ * the receipt.
+ */
+
+import { createHash } from 'crypto';
+import { spawn } from 'child_process';
+import type { RiskGrade } from '../../shared/types/risk';
+
+/** argv-form process runner. `opts.env` carries secrets to the child only.
+ *  Mirrors PythonInterpreterResolver's RunCommand but adds cwd/env (needed for
+ *  git cwd + agent API-key env). Injected in tests; `defaultAgentRun` in prod. */
+export interface AgentRunResult { stdout: string; stderr: string; code: number | null }
+export type AgentRunFn = (
+  cmd: string,
+  args: ReadonlyArray<string>,
+  opts?: { cwd?: string; env?: Record<string, string | undefined> },
+) => Promise<AgentRunResult>;
+
+const RISK_ORDER: Record<RiskGrade, number> = { L1: 1, L2: 2, L3: 3 };
+
+/** Max (most severe) of two risk grades. */
+export function maxRisk(a: RiskGrade, b: RiskGrade): RiskGrade {
+  return RISK_ORDER[a] >= RISK_ORDER[b] ? a : b;
+}
+
+export interface DetectResult { available: boolean; version?: string }
+
+/** Detect a CLI binary + version via `<cmd> <versionArgs>`. available iff exit 0. */
+export async function detectBinary(
+  cmd: string,
+  versionArgs: ReadonlyArray<string>,
+  run: AgentRunFn,
+): Promise<DetectResult> {
+  try {
+    const res = await run(cmd, versionArgs);
+    if (res.code !== 0) return { available: false };
+    const m = /\d+\.\d+(?:\.\d+)?/.exec(`${res.stdout} ${res.stderr}`);
+    return { available: true, version: m ? m[0] : undefined };
+  } catch {
+    return { available: false };
+  }
+}
+
+/** True if the worktree has uncommitted changes (`git status --porcelain`). */
+export async function isWorktreeDirty(run: AgentRunFn, cwd: string): Promise<boolean> {
+  const res = await run('git', ['status', '--porcelain'], { cwd });
+  return !!res.stdout.trim();
+}
+
+/** Capture the working-tree diff. Robust: returns whatever git produced even on
+ *  a non-zero exit (e.g. when the agent itself failed mid-edit). */
+export async function captureGitDiff(run: AgentRunFn, cwd: string): Promise<string> {
+  try {
+    const res = await run('git', ['diff'], { cwd });
+    return res.stdout ?? '';
+  } catch {
+    return '';
+  }
+}
+
+export interface DiffSummary { files: number; additions: number; deletions: number; paths: string[] }
+
+/** Pure parse of a unified `git diff` into a summary (files, +/- lines, paths). */
+export function summarizeDiff(diff: string): DiffSummary {
+  if (!diff || !diff.trim()) return { files: 0, additions: 0, deletions: 0, paths: [] };
+  const paths: string[] = [];
+  let additions = 0;
+  let deletions = 0;
+  for (const line of diff.split('\n')) {
+    if (line.startsWith('diff --git')) {
+      const m = /^diff --git a\/(.+?) b\/(.+)$/.exec(line);
+      if (m) paths.push(m[2]);
+    } else if (line.startsWith('+') && !line.startsWith('+++')) {
+      additions++;
+    } else if (line.startsWith('-') && !line.startsWith('---')) {
+      deletions++;
+    }
+  }
+  return { files: paths.length, additions, deletions, paths };
+}
+
+/** Classify a diff's risk = the MAX tier across its changed paths, using the
+ *  injected classifier (PolicyEngine.classifyRisk at runtime). Empty diff = L1. */
+export function classifyDiffRisk(summary: DiffSummary, classify: (path: string) => RiskGrade): RiskGrade {
+  let grade: RiskGrade = 'L1';
+  for (const p of summary.paths) grade = maxRisk(grade, classify(p));
+  return grade;
+}
+
+export type AgentVerdict = 'ALLOW' | 'BLOCK' | 'ESCALATE';
+
+export interface AgentDecision { verdict: AgentVerdict; reason: string; riskGrade: RiskGrade }
+
+/**
+ * Deterministic gate decision for an agent run that produced `riskGrade`:
+ *   L3                       → ESCALATE (route to the L3 approval queue)
+ *   writes not permitted     → BLOCK
+ *   otherwise                → ALLOW
+ */
+export function decideAgentRun(riskGrade: RiskGrade, opts: { writesAllowed: boolean }): AgentDecision {
+  if (riskGrade === 'L3') {
+    return { verdict: 'ESCALATE', reason: 'L3-risk change requires human (L3) approval', riskGrade };
+  }
+  if (!opts.writesAllowed) {
+    return { verdict: 'BLOCK', reason: 'writes are not permitted in the current governance mode', riskGrade };
+  }
+  return { verdict: 'ALLOW', reason: 'within auto-approve risk tier', riskGrade };
+}
+
+export interface AgentReceipt {
+  receiptId: string;
+  agent: string;
+  /** argv actually spawned — secrets never travel in argv, so this is safe. */
+  argv: string[];
+  verdict: AgentVerdict;
+  verdictRationale: string;
+  riskGrade: RiskGrade;
+  exitCode: number | null;
+  diff: DiffSummary;
+  evidence: Array<{ kind: string; ref: string; summary?: string }>;
+  issuedAt: string;
+  issuedBy: string;
+}
+
+/** Build a receipt (conforms to the FailSafe receipt contract shape). Pure:
+ *  `issuedAt` is injected so the receipt is deterministic in tests. The receipt
+ *  records argv (never env) so no API key can leak through it. */
+export function buildAgentReceipt(input: {
+  agent: string;
+  argv: string[];
+  decision: AgentDecision;
+  exitCode: number | null;
+  diff: DiffSummary;
+  issuedAt: string;
+  issuedBy?: string;
+}): AgentReceipt {
+  const issuedBy = input.issuedBy ?? `did:failsafe:agent:${input.agent}`;
+  const receiptId = createHash('sha256')
+    .update(`${input.agent}|${input.issuedAt}|${input.diff.files}|${input.diff.additions}|${input.diff.deletions}|${input.argv.join(' ')}`)
+    .digest('hex')
+    .slice(0, 32);
+  return {
+    receiptId,
+    agent: input.agent,
+    argv: input.argv,
+    verdict: input.decision.verdict,
+    verdictRationale: input.decision.reason,
+    riskGrade: input.decision.riskGrade,
+    exitCode: input.exitCode,
+    diff: input.diff,
+    evidence: [{ kind: 'cli_agent_diff', ref: `${input.diff.files} file(s)`, summary: `+${input.diff.additions}/-${input.diff.deletions}` }],
+    issuedAt: input.issuedAt,
+    issuedBy,
+  };
+}
+
+/** Shared outcome shape for a governed agent run (used by both wrappers + the
+ *  command layer). */
+export interface AgentRunOutcome {
+  available: boolean;
+  spawned: boolean;
+  decision?: AgentDecision;
+  diff?: DiffSummary;
+  receipt?: AgentReceipt;
+  stdout?: string;
+  error?: string;
+}
+
+/** Default argv-form runner (production). `shell: false` — no shell-injection
+ *  surface. cwd/env optional; env carries secrets to the child only. */
+export const defaultAgentRun: AgentRunFn = (cmd, args, opts) =>
+  new Promise((resolve) => {
+    const child = spawn(cmd, [...args], { shell: false, cwd: opts?.cwd, env: opts?.env ?? process.env });
+    let stdout = '';
+    let stderr = '';
+    child.stdout?.on('data', (c: Buffer) => { stdout += c.toString(); });
+    child.stderr?.on('data', (c: Buffer) => { stderr += c.toString(); });
+    child.on('error', () => resolve({ stdout, stderr, code: 127 }));
+    child.on('close', (code: number | null) => resolve({ stdout, stderr, code }));
+  });

--- a/FailSafe/extension/src/integrations/agent-cli/aider-wrapper.ts
+++ b/FailSafe/extension/src/integrations/agent-cli/aider-wrapper.ts
@@ -1,0 +1,78 @@
+/**
+ * aider-wrapper — FailSafe git-gate wrapper for the Aider CLI (#107). Detects
+ * `aider`, refuses a dirty worktree unless explicitly allowed, runs argv-form
+ * with auto-commit OFF by default (changes stay uncommitted for review),
+ * captures the before/after diff robustly even when Aider exits non-zero, and
+ * routes a high-risk (L3) diff to escalation.
+ *
+ * Verified surface (issue #107): Aider git integration + `--message` scripting.
+ * Flags used are documented at https://aider.chat/docs/ (`--no-auto-commits`,
+ * `--message`, `--yes`); see docs/integrations/INTEGRATION_DOCS_INDEX.md.
+ */
+
+import type { RiskGrade } from '../../shared/types/risk';
+import {
+  type AgentRunFn, type DiffSummary, type AgentReceipt, type AgentDecision, type AgentRunOutcome,
+  detectBinary, captureGitDiff, summarizeDiff, classifyDiffRisk, decideAgentRun,
+  buildAgentReceipt, isWorktreeDirty,
+} from './agent-cli-core';
+
+export async function detectAider(run: AgentRunFn): Promise<{ available: boolean; version?: string }> {
+  return detectBinary('aider', ['--version'], run);
+}
+
+/** Pure argv builder. Auto-commit is OFF unless `autoCommit` is explicitly set. */
+export function buildAiderArgs(prompt: string, opts: { autoCommit?: boolean } = {}): string[] {
+  const args = ['--message', prompt, '--yes'];
+  args.push(opts.autoCommit ? '--auto-commits' : '--no-auto-commits');
+  return args;
+}
+
+export interface AiderRunOptions {
+  prompt: string;
+  cwd: string;
+  /** Allow running against a dirty worktree (default false → refuse). */
+  allowDirty?: boolean;
+  /** Enable Aider auto-commit (default false). */
+  autoCommit?: boolean;
+  writesAllowed: boolean;
+}
+
+export interface AiderDeps {
+  run: AgentRunFn;
+  classify: (path: string) => RiskGrade;
+  issuedAt: string;
+}
+
+const EMPTY_DIFF: DiffSummary = { files: 0, additions: 0, deletions: 0, paths: [] };
+
+function receiptFor(decision: AgentDecision, argv: string[], exitCode: number | null, diff: DiffSummary, issuedAt: string): AgentReceipt {
+  return buildAgentReceipt({ agent: 'aider', argv, decision, exitCode, diff, issuedAt });
+}
+
+/**
+ * Govern an Aider run. Pre-run gate: refuse a dirty worktree unless allowed
+ * (BLOCK, no spawn). Then run argv-form (auto-commit off), capture the resulting
+ * diff robustly, classify it, and decide ALLOW / BLOCK / ESCALATE-to-L3.
+ */
+export async function runAiderGoverned(opts: AiderRunOptions, deps: AiderDeps): Promise<AgentRunOutcome> {
+  const det = await detectAider(deps.run);
+  if (!det.available) return { available: false, spawned: false, error: '`aider` not found on PATH' };
+
+  const argv = buildAiderArgs(opts.prompt, { autoCommit: opts.autoCommit });
+
+  // Pre-run gate: dirty worktree refusal.
+  if (!opts.allowDirty && (await isWorktreeDirty(deps.run, opts.cwd))) {
+    const decision: AgentDecision = { verdict: 'BLOCK', reason: 'worktree has uncommitted changes; refusing to run Aider (set allowDirty to override)', riskGrade: 'L1' };
+    return { available: true, spawned: false, decision, receipt: receiptFor(decision, argv, null, EMPTY_DIFF, deps.issuedAt) };
+  }
+
+  // Run argv-form; auto-commit off so changes stay uncommitted for the gate.
+  const res = await deps.run('aider', argv, { cwd: opts.cwd });
+
+  // Capture the diff robustly even if Aider exited non-zero.
+  const diff = summarizeDiff(await captureGitDiff(deps.run, opts.cwd));
+  const risk = classifyDiffRisk(diff, deps.classify);
+  const decision = decideAgentRun(risk, { writesAllowed: opts.writesAllowed });
+  return { available: true, spawned: true, decision, diff, receipt: receiptFor(decision, argv, res.code, diff, deps.issuedAt), stdout: res.stdout };
+}

--- a/FailSafe/extension/src/integrations/agent-cli/continue-wrapper.ts
+++ b/FailSafe/extension/src/integrations/agent-cli/continue-wrapper.ts
@@ -1,0 +1,95 @@
+/**
+ * continue-wrapper — FailSafe governance wrapper for the Continue headless CLI
+ * (`cn`, #104). Detects `cn`, maps the requested `--allow` tool allowlist to a
+ * FailSafe risk tier, gates BEFORE spawning (a write/shell allowlist never runs
+ * un-approved), runs argv-form with the API key in the child ENV only, then
+ * classifies the produced diff and routes any surprise L3 change to escalation.
+ *
+ * Verified surface (issue #104): `cn -p <prompt>` headless, `CONTINUE_API_KEY`
+ * env, explicit `--allow <tool>` permissions. The API key is NEVER placed in
+ * argv or the receipt — only in the child env.
+ */
+
+import type { RiskGrade } from '../../shared/types/risk';
+import {
+  type AgentRunFn, type AgentRunOutcome,
+  detectBinary, captureGitDiff, summarizeDiff, classifyDiffRisk, decideAgentRun,
+  buildAgentReceipt, maxRisk,
+} from './agent-cli-core';
+
+/** Tool-name fragments that imply shell/exec power (highest tier). */
+const SHELL_TOOLS = ['shell', 'exec', 'bash', 'command', 'run', 'terminal', 'process'];
+/** Tool-name fragments that imply file writes (medium tier). */
+const WRITE_TOOLS = ['write', 'edit', 'create', 'apply', 'delete', 'patch', 'insert'];
+
+/** Map a Continue `--allow` tool allowlist to a FailSafe risk tier (max across
+ *  entries). shell/exec → L3, file-write → L2, read-only/empty → L1. */
+export function mapAllowlistToRisk(allow: ReadonlyArray<string>): RiskGrade {
+  let grade: RiskGrade = 'L1';
+  for (const raw of allow) {
+    const t = (raw || '').toLowerCase();
+    if (SHELL_TOOLS.some((s) => t.includes(s))) grade = maxRisk(grade, 'L3');
+    else if (WRITE_TOOLS.some((s) => t.includes(s))) grade = maxRisk(grade, 'L2');
+  }
+  return grade;
+}
+
+/** Pure argv builder. argv only — the API key is NOT here (it goes via env). */
+export function buildContinueArgs(prompt: string, allow: ReadonlyArray<string>): string[] {
+  const args = ['-p', prompt];
+  for (const tool of allow) args.push('--allow', tool);
+  return args;
+}
+
+export async function detectContinue(run: AgentRunFn): Promise<{ available: boolean; version?: string }> {
+  return detectBinary('cn', ['--version'], run);
+}
+
+export interface ContinueRunOptions {
+  prompt: string;
+  allow: ReadonlyArray<string>;
+  apiKey?: string;
+  cwd: string;
+  writesAllowed: boolean;
+  /** Base environment to inherit (the API key is overlaid onto this). */
+  baseEnv?: Record<string, string | undefined>;
+}
+
+export interface ContinueDeps {
+  run: AgentRunFn;
+  classify: (path: string) => RiskGrade;
+  issuedAt: string;
+}
+
+export type { AgentRunOutcome };
+
+/**
+ * Govern a Continue headless run. Two-phase gate: the allowlist tier is checked
+ * BEFORE spawning (a write/shell allowlist that is L3, or any write when writes
+ * are disallowed, never spawns); only an auto-approve allowlist runs, after
+ * which the actual diff is re-classified and a surprise L3 change escalates.
+ */
+export async function runContinueGoverned(opts: ContinueRunOptions, deps: ContinueDeps): Promise<AgentRunOutcome> {
+  const det = await detectContinue(deps.run);
+  if (!det.available) return { available: false, spawned: false, error: '`cn` (Continue CLI) not found on PATH' };
+
+  const argv = buildContinueArgs(opts.prompt, opts.allow);
+  const allowlistRisk = mapAllowlistToRisk(opts.allow);
+
+  // Phase 1 — pre-run gate on the requested tool permissions.
+  const pre = decideAgentRun(allowlistRisk, { writesAllowed: opts.writesAllowed });
+  if (pre.verdict !== 'ALLOW') {
+    const receipt = buildAgentReceipt({ agent: 'continue', argv, decision: pre, exitCode: null, diff: { files: 0, additions: 0, deletions: 0, paths: [] }, issuedAt: deps.issuedAt });
+    return { available: true, spawned: false, decision: pre, receipt };
+  }
+
+  // Phase 2 — run argv-form; API key in the child ENV only (never argv/receipt).
+  const env = { ...(opts.baseEnv ?? {}), ...(opts.apiKey ? { CONTINUE_API_KEY: opts.apiKey } : {}) };
+  const res = await deps.run('cn', argv, { cwd: opts.cwd, env });
+
+  const diff = summarizeDiff(await captureGitDiff(deps.run, opts.cwd));
+  const finalRisk = maxRisk(allowlistRisk, classifyDiffRisk(diff, deps.classify));
+  const decision = decideAgentRun(finalRisk, { writesAllowed: opts.writesAllowed });
+  const receipt = buildAgentReceipt({ agent: 'continue', argv, decision, exitCode: res.code, diff, issuedAt: deps.issuedAt });
+  return { available: true, spawned: true, decision, diff, receipt, stdout: res.stdout };
+}

--- a/FailSafe/extension/src/test/integrations/agent-cli/agent-cli.test.ts
+++ b/FailSafe/extension/src/test/integrations/agent-cli/agent-cli.test.ts
@@ -1,0 +1,201 @@
+import { strict as assert } from 'assert';
+import type { RiskGrade } from '../../../shared/types/risk';
+import {
+  type AgentRunFn, type AgentRunResult,
+  maxRisk, detectBinary, summarizeDiff, classifyDiffRisk, decideAgentRun, buildAgentReceipt,
+} from '../../../integrations/agent-cli/agent-cli-core';
+import { mapAllowlistToRisk, buildContinueArgs, runContinueGoverned } from '../../../integrations/agent-cli/continue-wrapper';
+import { buildAiderArgs, runAiderGoverned } from '../../../integrations/agent-cli/aider-wrapper';
+
+// ---- test fakes ---------------------------------------------------------
+
+interface RunCall { cmd: string; args: string[]; opts?: { cwd?: string; env?: Record<string, string | undefined> } }
+
+interface FakeOpts {
+  cnVersionCode?: number; aiderVersionCode?: number;
+  dirty?: boolean; diff?: string; cnCode?: number; aiderCode?: number;
+}
+
+function makeRunner(o: FakeOpts = {}): { run: AgentRunFn; calls: RunCall[] } {
+  const calls: RunCall[] = [];
+  const run: AgentRunFn = async (cmd, args, opts) => {
+    calls.push({ cmd, args: [...args], opts });
+    const a = [...args];
+    const r = (stdout: string, code: number | null = 0): AgentRunResult => ({ stdout, stderr: '', code });
+    if (cmd === 'cn' && a[0] === '--version') return r('cn 1.2.3', o.cnVersionCode ?? 0);
+    if (cmd === 'aider' && a[0] === '--version') return r('aider 0.50.1', o.aiderVersionCode ?? 0);
+    if (cmd === 'git' && a[0] === 'status') return r(o.dirty ? ' M src/x.ts\n' : '');
+    if (cmd === 'git' && a[0] === 'diff') return r(o.diff ?? '');
+    if (cmd === 'cn') return r('{"ok":true}', o.cnCode ?? 0);
+    if (cmd === 'aider') return r('applied', o.aiderCode ?? 0);
+    return r('');
+  };
+  return { run, calls };
+}
+
+// classify: paths under src/security/** are L3, src/** is L2, else L1.
+const classify = (path: string): RiskGrade =>
+  /(^|\/)security\//.test(path) ? 'L3' : path.startsWith('src/') ? 'L2' : 'L1';
+
+const L1_DIFF = 'diff --git a/README.md b/README.md\n--- a/README.md\n+++ b/README.md\n+a line\n';
+const L3_DIFF = 'diff --git a/src/security/Auth.ts b/src/security/Auth.ts\n--- a/src/security/Auth.ts\n+++ b/src/security/Auth.ts\n-old\n+new1\n+new2\n';
+
+// ---- core ---------------------------------------------------------------
+
+suite('agent-cli-core (Group B)', () => {
+  test('maxRisk picks the most severe', () => {
+    assert.equal(maxRisk('L1', 'L3'), 'L3');
+    assert.equal(maxRisk('L2', 'L1'), 'L2');
+  });
+
+  test('detectBinary: available iff exit 0, parses version', async () => {
+    const { run } = makeRunner();
+    assert.deepEqual(await detectBinary('cn', ['--version'], run), { available: true, version: '1.2.3' });
+    const { run: bad } = makeRunner({ cnVersionCode: 127 });
+    assert.deepEqual(await detectBinary('cn', ['--version'], bad), { available: false });
+  });
+
+  test('summarizeDiff counts files / +/- lines / paths', () => {
+    const s = summarizeDiff(L3_DIFF);
+    assert.deepEqual(s.paths, ['src/security/Auth.ts']);
+    assert.equal(s.files, 1);
+    assert.equal(s.additions, 2);
+    assert.equal(s.deletions, 1);
+    assert.deepEqual(summarizeDiff(''), { files: 0, additions: 0, deletions: 0, paths: [] });
+  });
+
+  test('classifyDiffRisk = max tier across changed paths', () => {
+    assert.equal(classifyDiffRisk(summarizeDiff(L1_DIFF), classify), 'L1');
+    assert.equal(classifyDiffRisk(summarizeDiff(L3_DIFF), classify), 'L3');
+  });
+
+  test('decideAgentRun: L3→ESCALATE, no-writes→BLOCK, else ALLOW', () => {
+    assert.equal(decideAgentRun('L3', { writesAllowed: true }).verdict, 'ESCALATE');
+    assert.equal(decideAgentRun('L2', { writesAllowed: false }).verdict, 'BLOCK');
+    assert.equal(decideAgentRun('L1', { writesAllowed: true }).verdict, 'ALLOW');
+  });
+
+  test('buildAgentReceipt is deterministic + never carries env/secret', () => {
+    const r = buildAgentReceipt({ agent: 'continue', argv: ['-p', 'hi'], decision: { verdict: 'ALLOW', reason: 'ok', riskGrade: 'L1' }, exitCode: 0, diff: summarizeDiff(L1_DIFF), issuedAt: '2026-06-04T00:00:00Z' });
+    assert.equal(r.verdict, 'ALLOW');
+    assert.equal(r.issuedBy, 'did:failsafe:agent:continue');
+    assert.ok(r.receiptId.length === 32);
+    assert.ok(!JSON.stringify(r).includes('CONTINUE_API_KEY'));
+  });
+});
+
+// ---- Continue (#104) ----------------------------------------------------
+
+suite('continue-wrapper (#104)', () => {
+  test('mapAllowlistToRisk: shell→L3, write→L2, read/empty→L1', () => {
+    assert.equal(mapAllowlistToRisk([]), 'L1');
+    assert.equal(mapAllowlistToRisk(['read', 'search']), 'L1');
+    assert.equal(mapAllowlistToRisk(['editFile']), 'L2');
+    assert.equal(mapAllowlistToRisk(['runTerminalCommand']), 'L3');
+    assert.equal(mapAllowlistToRisk(['read', 'writeFile', 'shell']), 'L3');
+  });
+
+  test('buildContinueArgs is argv-form with -p + repeated --allow (no shell string)', () => {
+    assert.deepEqual(buildContinueArgs('do it', ['read', 'editFile']), ['-p', 'do it', '--allow', 'read', '--allow', 'editFile']);
+  });
+
+  test('detect failure → available:false, no spawn', async () => {
+    const { run, calls } = makeRunner({ cnVersionCode: 127 });
+    const out = await runContinueGoverned({ prompt: 'x', allow: [], cwd: '/repo', writesAllowed: true }, { run, classify, issuedAt: 'T' });
+    assert.equal(out.available, false);
+    assert.equal(calls.some((c) => c.cmd === 'cn' && c.args[0] !== '--version'), false);
+  });
+
+  test('no-tool mode (empty allowlist, L1) → ALLOW, spawns, captures diff + receipt', async () => {
+    const { run, calls } = makeRunner({ diff: L1_DIFF });
+    const out = await runContinueGoverned({ prompt: 'tidy', allow: [], cwd: '/repo', writesAllowed: true }, { run, classify, issuedAt: 'T' });
+    assert.equal(out.spawned, true);
+    assert.equal(out.decision?.verdict, 'ALLOW');
+    assert.equal(out.diff?.additions, 1);
+    assert.equal(out.receipt?.exitCode, 0);
+    assert.ok(calls.some((c) => c.cmd === 'cn' && c.args.includes('-p')));
+  });
+
+  test('write-request mode (shell allowlist, L3) → ESCALATE BEFORE spawning', async () => {
+    const { run, calls } = makeRunner({ diff: L1_DIFF });
+    const out = await runContinueGoverned({ prompt: 'rm stuff', allow: ['runShellCommand'], cwd: '/repo', writesAllowed: true }, { run, classify, issuedAt: 'T' });
+    assert.equal(out.decision?.verdict, 'ESCALATE');
+    assert.equal(out.spawned, false, 'a dangerous allowlist must not spawn');
+    assert.equal(calls.some((c) => c.cmd === 'cn' && c.args.includes('-p')), false);
+  });
+
+  test('writes-disallowed + write allowlist → BLOCK before spawning', async () => {
+    const { run } = makeRunner();
+    const out = await runContinueGoverned({ prompt: 'x', allow: ['editFile'], cwd: '/repo', writesAllowed: false }, { run, classify, issuedAt: 'T' });
+    assert.equal(out.decision?.verdict, 'BLOCK');
+    assert.equal(out.spawned, false);
+  });
+
+  test('surprise L3 diff from an L1 allowlist → ESCALATE post-run', async () => {
+    const { run } = makeRunner({ diff: L3_DIFF });
+    const out = await runContinueGoverned({ prompt: 'edit', allow: [], cwd: '/repo', writesAllowed: true }, { run, classify, issuedAt: 'T' });
+    assert.equal(out.spawned, true);
+    assert.equal(out.decision?.verdict, 'ESCALATE');
+  });
+
+  test('failed run capture: cn exits non-zero → still captures diff + receipt.exitCode', async () => {
+    const { run } = makeRunner({ diff: L1_DIFF, cnCode: 2 });
+    const out = await runContinueGoverned({ prompt: 'x', allow: [], cwd: '/repo', writesAllowed: true }, { run, classify, issuedAt: 'T' });
+    assert.equal(out.spawned, true);
+    assert.equal(out.receipt?.exitCode, 2);
+  });
+
+  test('SECRET: API key goes in child env ONLY — never argv, never receipt', async () => {
+    const { run, calls } = makeRunner({ diff: L1_DIFF });
+    const out = await runContinueGoverned({ prompt: 'x', allow: [], apiKey: 'CONT_TOPSECRET', cwd: '/repo', writesAllowed: true }, { run, classify, issuedAt: 'T' });
+    const cnCall = calls.find((c) => c.cmd === 'cn' && c.args.includes('-p'))!;
+    assert.equal(cnCall.opts?.env?.CONTINUE_API_KEY, 'CONT_TOPSECRET', 'key passed via child env');
+    assert.ok(!cnCall.args.join(' ').includes('CONT_TOPSECRET'), 'key never in argv');
+    assert.ok(!JSON.stringify(out.receipt).includes('CONT_TOPSECRET'), 'key never in receipt');
+  });
+});
+
+// ---- Aider (#107) -------------------------------------------------------
+
+suite('aider-wrapper (#107)', () => {
+  test('buildAiderArgs: --message + --yes; auto-commit OFF by default', () => {
+    assert.deepEqual(buildAiderArgs('fix bug'), ['--message', 'fix bug', '--yes', '--no-auto-commits']);
+    assert.deepEqual(buildAiderArgs('fix bug', { autoCommit: true }), ['--message', 'fix bug', '--yes', '--auto-commits']);
+  });
+
+  test('detect → clean run → ALLOW with captured diff', async () => {
+    const { run, calls } = makeRunner({ dirty: false, diff: L1_DIFF });
+    const out = await runAiderGoverned({ prompt: 'tidy', cwd: '/repo', writesAllowed: true }, { run, classify, issuedAt: 'T' });
+    assert.equal(out.spawned, true);
+    assert.equal(out.decision?.verdict, 'ALLOW');
+    assert.equal(out.diff?.additions, 1);
+    assert.ok(calls.some((c) => c.cmd === 'aider' && c.args.includes('--no-auto-commits')));
+  });
+
+  test('dirty worktree → BLOCK, refuses to spawn (unless allowDirty)', async () => {
+    const { run, calls } = makeRunner({ dirty: true, diff: L1_DIFF });
+    const out = await runAiderGoverned({ prompt: 'x', cwd: '/repo', writesAllowed: true }, { run, classify, issuedAt: 'T' });
+    assert.equal(out.decision?.verdict, 'BLOCK');
+    assert.equal(out.spawned, false);
+    assert.equal(calls.some((c) => c.cmd === 'aider' && c.args.includes('--message')), false);
+    // override
+    const { run: run2 } = makeRunner({ dirty: true, diff: L1_DIFF });
+    const out2 = await runAiderGoverned({ prompt: 'x', cwd: '/repo', allowDirty: true, writesAllowed: true }, { run: run2, classify, issuedAt: 'T' });
+    assert.equal(out2.spawned, true);
+  });
+
+  test('high-risk diff gate: L3 change → ESCALATE', async () => {
+    const { run } = makeRunner({ dirty: false, diff: L3_DIFF });
+    const out = await runAiderGoverned({ prompt: 'touch auth', cwd: '/repo', writesAllowed: true }, { run, classify, issuedAt: 'T' });
+    assert.equal(out.decision?.verdict, 'ESCALATE');
+    assert.equal(out.receipt?.riskGrade, 'L3');
+  });
+
+  test('diff capture robust when Aider exits non-zero', async () => {
+    const { run } = makeRunner({ dirty: false, diff: L1_DIFF, aiderCode: 1 });
+    const out = await runAiderGoverned({ prompt: 'x', cwd: '/repo', writesAllowed: true }, { run, classify, issuedAt: 'T' });
+    assert.equal(out.spawned, true);
+    assert.equal(out.receipt?.exitCode, 1);
+    assert.equal(out.diff?.files, 1);
+  });
+});


### PR DESCRIPTION
## Summary
Closes **#104** and **#107** (Group B — CLI agent wrappers). Wraps a headless coding-agent CLI so FailSafe governs the diff it produces: detect → classify risk with the **live PolicyEngine** → decide ALLOW / BLOCK / ESCALATE-to-L3 → emit a receipt. **argv-form spawn only** (`shell: false` — no command strings, no shell-injection surface); secrets travel via the child **ENV**, never argv and never the receipt. Off by default; the testable core uses an injected runner so **no live process is spawned in tests**.

## Shared substrate (`agent-cli-core.ts`)
`detectBinary` · `isWorktreeDirty` · `captureGitDiff` (robust on non-zero exit) · `summarizeDiff` · `classifyDiffRisk` (max tier across changed paths via injected `PolicyEngine.classifyRisk`) · `decideAgentRun` (L3→ESCALATE, no-writes→BLOCK, else ALLOW) · `buildAgentReceipt` (deterministic; receipt-contract shape; never carries env/secret) · `defaultAgentRun` (`spawn(shell:false)` + cwd/env).

## Continue (#104)
Detect `cn`; map the `--allow` allowlist → risk tier (shell→L3, write→L2, read→L1). **Two-phase gate**: a dangerous allowlist **ESCALATES before spawning**; only an auto-approve allowlist runs, after which the actual diff is re-classified and a **surprise L3 change escalates**. `CONTINUE_API_KEY` is passed in the child env only.

| Acceptance | Where |
|---|---|
| argv-form spawn, not shell strings | `buildContinueArgs` + `defaultAgentRun(shell:false)` |
| No API key logged | key in child env only; masking test asserts absent from argv + receipt |
| Tool allowlist → risk tier | `mapAllowlistToRisk` |
| Tests: detect, no-tool, write-request, failed-run | ✅ all present |

## Aider (#107)
Detect `aider`; **refuse a dirty worktree** unless allowed (BLOCK, no spawn); run with **auto-commit OFF** (`--no-auto-commits`) so changes stay uncommitted for the gate; capture the diff robustly even on non-zero exit; route an **L3 diff to escalation**.

| Acceptance | Where |
|---|---|
| Refuses dirty worktree unless allowed | `isWorktreeDirty` pre-run gate + test |
| Diff capture robust on non-zero exit | `captureGitDiff` + test |
| Auto-commit off unless configured | `buildAiderArgs` default `--no-auto-commits` + test |
| Tests: detect, clean, dirty-refusal, high-risk gate | ✅ all present |

## Wiring (grounded in real APIs)
`failsafe.continue.run` / `failsafe.aider.run` classify with the live `PolicyEngine.classifyRisk` and, on ESCALATE, enqueue a **real** L3 approval via `QorLogicManager.queueL3Approval(...)` (`shared/types/risk.ts` `RiskGrade`, `shared/types/l3-approval.ts`). Config: `failsafe.integrations.continue.{enabled, apiKey(secret), allow, allowWrites}` + `failsafe.integrations.aider.{enabled, allowDirty, autoCommit, allowWrites}`.

## Scope / notes
- **Safety:** a dangerous allowlist or dirty worktree **never spawns**; sub-L3 writes need an explicit `allowWrites` opt-in; L3 always escalates. No silent writes.
- The `INTEGRATION_DOCS_INDEX` rows for Continue/Aider promote from *Planned* → *In review* (with the Aider flag-source note) at batch-squash time — the index lives on the unmerged Sentry PR #150, so editing it here would force a conflict.
- Aider flags (`--no-auto-commits`, `--message`, `--yes`) per https://aider.chat/docs/ ; Continue (`cn -p`, `--allow`, `CONTINUE_API_KEY`) per the #104 verified surface.

Full `test:all` runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)