### PR TITLE
feat(integrations): agent observe/audit adapters — OpenHands + Cline/Roo/Kilo (#105, #106)

### DIFF
--- a/FailSafe/extension/package.json
+++ b/FailSafe/extension/package.json
@@ -68,7 +68,9 @@
     "onCommand:failsafe.uninstallVoicePack",
     "onCommand:failsafe.substrate.run",
     "onCommand:failsafe.sarif.import",
-    "onCommand:failsafe.mcp.installCatalog"
+    "onCommand:failsafe.mcp.installCatalog",
+    "onCommand:failsafe.agentAudit.run",
+    "onCommand:failsafe.openhands.observe"
   ],
   "main": "./dist/extension/main.js",
   "contributes": {
@@ -125,6 +127,16 @@
       {
         "command": "failsafe.mcp.installCatalog",
         "title": "FailSafe: Install MCP Integration (governed)",
+        "category": "FailSafe"
+      },
+      {
+        "command": "failsafe.agentAudit.run",
+        "title": "FailSafe: Audit Agent MCP Policy (Cline/Roo/Kilo)",
+        "category": "FailSafe"
+      },
+      {
+        "command": "failsafe.openhands.observe",
+        "title": "FailSafe: Import OpenHands Run (observe)",
         "category": "FailSafe"
       },
       {
@@ -310,6 +322,21 @@
           "type": "string",
           "default": "",
           "markdownDescription": "Slack **incoming webhook URL** to post governance notifications to. Treat as a secret — it grants posting to the target channel. Messages are notify-only (no interactive approvals; a link back to the local Command Center is included). Leave empty to disable."
+        },
+        "failsafe.integrations.agentAudit.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable the read-only Cline/Roo/Kilo MCP-policy audit. The `FailSafe: Audit Agent MCP Policy` command scans known workspace MCP config files and upserts risk records for risky posture (remote MCP servers, wildcard auto-approval, shell-capable tools). Secrets (env values, URL tokens) are redacted before any record is written. Read-only; works when the agents are absent."
+        },
+        "failsafe.integrations.openhands.enabled": {
+          "type": "boolean",
+          "default": false,
+          "description": "Enable the read-only OpenHands run observer. The `FailSafe: Import OpenHands Run (observe)` command maps an exported run's events into FailSafe transparency records and degrades on an unsupported version. Read-only; never mutates an active run."
+        },
+        "failsafe.integrations.openhands.version": {
+          "type": "string",
+          "default": "",
+          "description": "Optional OpenHands version (e.g. 0.30.1) used for the supported-version gate when the run export does not declare one. Versions outside the supported major lines degrade gracefully."
         },
         "failsafe.integrations.openDesign.mcpEnabled": {
           "type": "boolean",

--- a/FailSafe/extension/src/extension/agent-observe-command.ts
+++ b/FailSafe/extension/src/extension/agent-observe-command.ts
@@ -1,0 +1,81 @@
+/**
+ * agent-observe-command — Group C read-only observe/audit commands:
+ *   `FailSafe: Audit Agent MCP Policy (Cline/Roo/Kilo)`  (#106)
+ *   `FailSafe: Import OpenHands Run (observe)`            (#105)
+ *
+ * Both are READ-ONLY. The MCP policy audit scans known workspace config files,
+ * flags risky posture (remote MCP, wildcard auto-approval, shell-capable tools),
+ * and upserts the findings as risk records — secrets are redacted by the pure
+ * auditor before they reach a record. The OpenHands observer maps an exported
+ * run's events into normalized transparency records and degrades on an
+ * unsupported version. Neither spawns a process or mutates an agent.
+ */
+
+import * as vscode from 'vscode';
+import * as fs from 'fs';
+import * as path from 'path';
+import { auditMcpConfig } from '../integrations/agent-observe/mcp-policy-audit';
+import { observeOpenHandsRun } from '../integrations/agent-observe/openhands-observer';
+import { RiskRegisterManager } from '../roadmap/services/RiskRegisterManager';
+
+/** Best-effort known MCP/tool config locations (workspace-relative). `.mcp.json`
+ *  is the shared project MCP config Cline/Roo/Kilo all read. */
+const MCP_CONFIG_CANDIDATES: Array<{ agent: string; rel: string }> = [
+  { agent: 'project', rel: '.mcp.json' },
+  { agent: 'cline', rel: 'cline_mcp_settings.json' },
+  { agent: 'cline', rel: path.join('.cline', 'mcp_settings.json') },
+  { agent: 'roo', rel: path.join('.roo', 'mcp.json') },
+  { agent: 'kilo', rel: path.join('.kilocode', 'mcp.json') },
+];
+
+export function registerAgentObserveCommands(context: vscode.ExtensionContext, workspaceRoot: string): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('failsafe.agentAudit.run', async () => {
+      const cfg = vscode.workspace.getConfiguration('failsafe');
+      if (!cfg.get<boolean>('integrations.agentAudit.enabled', false)) {
+        vscode.window.showWarningMessage('Agent MCP-policy audit is disabled. Enable `failsafe.integrations.agentAudit.enabled`.');
+        return;
+      }
+      const riskManager = new RiskRegisterManager(workspaceRoot);
+      let scanned = 0;
+      let total = 0;
+      let high = 0;
+      for (const cand of MCP_CONFIG_CANDIDATES) {
+        const file = path.join(workspaceRoot, cand.rel);
+        let text: string;
+        try { text = fs.readFileSync(file, 'utf-8'); } catch { continue; }
+        scanned++;
+        for (const risk of auditMcpConfig(cand.agent, text)) {
+          riskManager.upsertRisk(risk as unknown as Record<string, unknown>);
+          total++;
+          if (risk.severity === 'high') high++;
+        }
+      }
+      if (scanned === 0) { vscode.window.showInformationMessage('Agent MCP-policy audit: no Cline/Roo/Kilo/project MCP config found in this workspace.'); return; }
+      vscode.window.showInformationMessage(`Agent MCP-policy audit: scanned ${scanned} config(s) → ${total} risk(s) upserted (${high} high-severity).`);
+    }),
+
+    vscode.commands.registerCommand('failsafe.openhands.observe', async () => {
+      const cfg = vscode.workspace.getConfiguration('failsafe');
+      if (!cfg.get<boolean>('integrations.openhands.enabled', false)) {
+        vscode.window.showWarningMessage('OpenHands observer is disabled. Enable `failsafe.integrations.openhands.enabled`.');
+        return;
+      }
+      const picked = await vscode.window.showOpenDialog({ canSelectMany: false, openLabel: 'Observe OpenHands run', filters: { 'OpenHands run (JSON)': ['json'] } });
+      if (!picked || picked.length === 0) return;
+      let parsed: unknown;
+      try { parsed = JSON.parse(fs.readFileSync(picked[0].fsPath, 'utf-8')); } catch (e) {
+        vscode.window.showErrorMessage(`OpenHands observe: cannot read/parse file: ${e instanceof Error ? e.message : String(e)}`); return;
+      }
+      // Accept either a bare events array or a { version, events } envelope.
+      const env = parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? (parsed as Record<string, unknown>) : null;
+      const events = env && Array.isArray(env.events) ? env.events : parsed;
+      const version = (env && typeof env.version === 'string' ? env.version : undefined) ?? (cfg.get<string>('integrations.openhands.version', '') || undefined);
+
+      const result = observeOpenHandsRun(events, version);
+      if (!result.supported) { vscode.window.showWarningMessage(`OpenHands observe: ${result.degraded}`); return; }
+      const high = result.records.filter((r) => r.riskHint === 'high').length;
+      vscode.window.showInformationMessage(`OpenHands observe: mapped ${result.records.length} event(s) (${high} high-risk) from ${vscode.workspace.asRelativePath(picked[0].fsPath)}.`);
+    }),
+  );
+}

--- a/FailSafe/extension/src/extension/main.ts
+++ b/FailSafe/extension/src/extension/main.ts
@@ -41,6 +41,7 @@ import { bootstrapStartupChecks } from "./bootstrapStartupChecks";
 import { registerSubstrateCommand } from "./substrate-command";
 import { registerSarifImportCommand } from "./sarif-command";
 import { registerMcpInstallCommand } from "./mcp-install-command";
+import { registerAgentObserveCommands } from "./agent-observe-command";
 import { SlackNotifier } from "../integrations/slack/SlackNotifier";
 import { defaultRun } from "../qorlogic/PythonInterpreterResolver";
 
@@ -164,6 +165,10 @@ export async function activate(
     // 3.14 Governed MCP install (B-INT-13/14): risk-scored install of catalog
     // MCP integrations (Context7, Mermaid Chart) into .mcp.json.
     registerMcpInstallCommand(context, core.workspaceRoot);
+
+    // 3.14e Agent observe/audit (Group C — #106 Cline/Roo/Kilo MCP-policy audit,
+    // #105 OpenHands run observer). Read-only; no spawning, no mutation.
+    registerAgentObserveCommands(context, core.workspaceRoot);
 
     // 3.15 Slack notify-only (B-INT-9 / #100): post governance enforcement
     // events to a configured incoming webhook. Disabled by default; non-blocking.

--- a/FailSafe/extension/src/integrations/agent-observe/mcp-policy-audit.ts
+++ b/FailSafe/extension/src/integrations/agent-observe/mcp-policy-audit.ts
@@ -1,0 +1,117 @@
+/**
+ * mcp-policy-audit — pure, read-only auditor for Cline / Roo / Kilo MCP & tool
+ * permission config (#106). Parses an MCP settings document defensively (these
+ * agents share the standard `mcpServers` shape but differ on the auto-approve
+ * field name — `alwaysAllow` vs `autoApprove` — so both are read), REDACTS all
+ * secret material (env values dropped, URL reduced to host), and flags risky
+ * posture: remote MCP servers, wildcard auto-approval, and shell-capable tools.
+ *
+ * Everything here is pure — no fs, no network. The command layer reads the
+ * files and feeds the text in. Risk records key-idempotently so re-auditing
+ * upserts rather than duplicates (same shape as the SARIF / Sentry ingests).
+ */
+
+export type RiskSeverity = 'high' | 'warn' | 'info';
+
+export interface McpServerPolicy {
+  name: string;
+  transport: 'local' | 'remote';
+  /** Local stdio command (basename only — no args/secrets). */
+  command?: string;
+  /** Remote host only — never the full URL (which can carry tokens). */
+  urlHost?: string;
+  /** Tool names this server auto-approves (no values). `*` = wildcard. */
+  autoApprove: string[];
+  /** ENV variable KEYS only — values are redacted (they are often secrets). */
+  envKeys: string[];
+}
+
+export interface McpPolicy {
+  servers: McpServerPolicy[];
+  /** Document-level auto-approve, if the agent stores it globally. */
+  globalAutoApprove: string[];
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim() ? v : undefined;
+}
+function strArray(v: unknown): string[] {
+  return Array.isArray(v) ? v.map(str).filter((s): s is string => !!s) : [];
+}
+/** Read whichever auto-approve field this agent variant uses. */
+function readAutoApprove(node: Record<string, unknown>): string[] {
+  return [...strArray(node.alwaysAllow), ...strArray(node.autoApprove), ...strArray(node.autoApproved)];
+}
+function hostOf(url: string): string | undefined {
+  try { return new URL(url).host; } catch { return undefined; }
+}
+
+const SHELL_HINTS = ['sh', 'bash', 'zsh', 'cmd', 'powershell', 'pwsh', 'exec', 'shell', 'node', 'python', 'deno', 'bun'];
+
+/** Defensive parse of an MCP settings document → normalized, redacted policy. */
+export function parseMcpPolicyConfig(json: unknown): McpPolicy {
+  const root = json && typeof json === 'object' ? (json as Record<string, unknown>) : {};
+  const serversNode = root.mcpServers && typeof root.mcpServers === 'object'
+    ? (root.mcpServers as Record<string, unknown>)
+    : {};
+  const servers: McpServerPolicy[] = [];
+  for (const [name, raw] of Object.entries(serversNode)) {
+    const node = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+    const url = str(node.url);
+    const command = str(node.command);
+    const isRemote = !!url || /^(sse|http|streamable-http|websocket)$/i.test(str(node.type) ?? '');
+    const envKeys = node.env && typeof node.env === 'object' && !Array.isArray(node.env)
+      ? Object.keys(node.env as Record<string, unknown>)
+      : [];
+    servers.push({
+      name,
+      transport: isRemote ? 'remote' : 'local',
+      command: command ? command.split(/[\\/]/).pop() : undefined, // basename only
+      urlHost: url ? hostOf(url) : undefined,
+      autoApprove: readAutoApprove(node),
+      envKeys,
+    });
+  }
+  return { servers, globalAutoApprove: readAutoApprove(root) };
+}
+
+export interface PolicyRisk { id: string; title: string; severity: RiskSeverity; source: 'mcp-policy'; status: 'open'; provenance: Record<string, unknown> }
+
+function isShellCapable(s: McpServerPolicy): boolean {
+  const cmd = (s.command ?? '').toLowerCase();
+  if (SHELL_HINTS.some((h) => cmd === h || cmd === `${h}.exe`)) return true;
+  return s.autoApprove.some((t) => SHELL_HINTS.some((h) => t.toLowerCase().includes(h)) || /shell|exec|terminal|command|run/i.test(t));
+}
+
+/** Flag risky MCP posture for one agent's parsed policy → keyed risk records. */
+export function flagMcpRisks(policy: McpPolicy, agent: string): PolicyRisk[] {
+  const risks: PolicyRisk[] = [];
+  const add = (server: string, flag: string, severity: RiskSeverity, title: string, detail: Record<string, unknown>) =>
+    risks.push({ id: `mcp-policy:${agent}:${server}:${flag}`, title, severity, source: 'mcp-policy', status: 'open', provenance: { agent, server, flag, ...detail } });
+
+  const wildcardGlobal = policy.globalAutoApprove.includes('*');
+  if (wildcardGlobal) add('*', 'wildcard-auto-approve', 'high', `${agent}: wildcard auto-approval (all tools)`, { scope: 'global' });
+
+  for (const s of policy.servers) {
+    if (s.autoApprove.includes('*')) add(s.name, 'wildcard-auto-approve', 'high', `${agent}: server "${s.name}" auto-approves all tools (*)`, { transport: s.transport });
+    if (s.transport === 'remote') add(s.name, 'remote-mcp', 'warn', `${agent}: remote MCP server "${s.name}"${s.urlHost ? ` (${s.urlHost})` : ''}`, { urlHost: s.urlHost });
+    if (isShellCapable(s)) add(s.name, 'shell-capable', 'high', `${agent}: shell/exec-capable MCP server "${s.name}"`, { command: s.command });
+    if (!s.autoApprove.includes('*') && s.autoApprove.length > 0) add(s.name, 'broad-auto-approve', 'info', `${agent}: server "${s.name}" auto-approves ${s.autoApprove.length} tool(s)`, { count: s.autoApprove.length });
+  }
+  return risks;
+}
+
+/** Audit one agent's config text → risk records (parse + flag). Dedup by id. */
+export function auditMcpConfig(agent: string, text: string): PolicyRisk[] {
+  let json: unknown;
+  try { json = JSON.parse(text); } catch { return []; }
+  const policy = parseMcpPolicyConfig(json);
+  const seen = new Set<string>();
+  const out: PolicyRisk[] = [];
+  for (const r of flagMcpRisks(policy, agent)) {
+    if (seen.has(r.id)) continue;
+    seen.add(r.id);
+    out.push(r);
+  }
+  return out;
+}

--- a/FailSafe/extension/src/integrations/agent-observe/openhands-observer.ts
+++ b/FailSafe/extension/src/integrations/agent-observe/openhands-observer.ts
@@ -1,0 +1,112 @@
+/**
+ * openhands-observer — pure, READ-ONLY observer adapter for OpenHands agent runs
+ * (#105). Maps OpenHands run/step events (actions + observations) into a
+ * normalized FailSafe transparency record. Documents the supported API surface
+ * and degrades gracefully on an unsupported version. Never mutates an active
+ * run: per the OpenHands contract, tools are fixed in the system prompt, so a
+ * tool-policy change must start a NEW conversation/fork rather than mutate a
+ * live run — this adapter only observes and so honors that by construction.
+ *
+ * Pure (no fs/network); the command layer supplies the events (e.g. from an
+ * exported run JSON) and the version string.
+ */
+
+export type RiskSeverity = 'high' | 'warn' | 'info';
+
+/** Documented supported OpenHands major lines (pre-2.0). See the docs index. */
+export const OPENHANDS_SUPPORTED_MAJORS = ['0', '1'] as const;
+
+/** True if `version`'s major is in the supported set. Undefined/garbage → false. */
+export function isOpenHandsVersionSupported(version: string | undefined, supported: ReadonlyArray<string> = OPENHANDS_SUPPORTED_MAJORS): boolean {
+  const m = /^(\d+)\./.exec((version ?? '').trim());
+  if (!m) return false;
+  return supported.includes(m[1]);
+}
+
+export interface AgentObservationEvent {
+  id: string;
+  source: 'openhands';
+  /** 'action' (agent did something) or 'observation' (environment responded). */
+  kind: 'action' | 'observation';
+  /** The action/observation verb (e.g. 'run', 'edit', 'read', 'browse'). */
+  verb: string;
+  tool?: string;
+  riskHint: RiskSeverity;
+  timestamp?: string;
+  summary: string;
+}
+
+const HIGH_VERBS = ['run', 'execute', 'cmd', 'command', 'shell', 'bash', 'browse'];
+const WARN_VERBS = ['edit', 'write', 'create', 'delete', 'patch', 'modify'];
+
+function riskHintFor(verb: string): RiskSeverity {
+  const v = verb.toLowerCase();
+  if (HIGH_VERBS.some((h) => v.includes(h))) return 'high';
+  if (WARN_VERBS.some((h) => v.includes(h))) return 'warn';
+  return 'info';
+}
+
+function str(v: unknown): string | undefined {
+  return typeof v === 'string' && v.trim() ? v : undefined;
+}
+
+/**
+ * Map one OpenHands event → a normalized observation record. Defensive: reads
+ * `action` (action event) or `observation` (observation event), a tool/command
+ * hint, and a timestamp; tolerates unknown shapes. Returns null for events with
+ * no recognizable verb (nothing meaningful to surface).
+ */
+export function mapOpenHandsEvent(raw: unknown, index = 0): AgentObservationEvent | null {
+  const e = raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : null;
+  if (!e) return null;
+  const actionVerb = str(e.action);
+  const obsVerb = str(e.observation);
+  const verb = actionVerb ?? obsVerb;
+  if (!verb) return null;
+  const kind: 'action' | 'observation' = actionVerb ? 'action' : 'observation';
+
+  const args = e.args && typeof e.args === 'object' ? (e.args as Record<string, unknown>) : {};
+  const tool = str(e.tool) ?? str((args as Record<string, unknown>).command) ?? str((args as Record<string, unknown>).path);
+  const id = str(e.id) ?? str(e.message_id) ?? `openhands:${index}`;
+
+  return {
+    id,
+    source: 'openhands',
+    kind,
+    verb,
+    tool,
+    riskHint: riskHintFor(verb),
+    timestamp: str(e.timestamp) ?? str(e.created_at),
+    summary: `${kind}:${verb}${tool ? ` (${tool})` : ''}`,
+  };
+}
+
+export interface ObserveResult {
+  supported: boolean;
+  degraded?: string;
+  records: AgentObservationEvent[];
+}
+
+/**
+ * Observe a sequence of OpenHands events. If a version is given and unsupported,
+ * degrade gracefully: surface a notice, map nothing (do not guess at a schema we
+ * do not support). Otherwise map all recognizable events.
+ */
+export function observeOpenHandsRun(events: unknown, version?: string): ObserveResult {
+  if (version !== undefined && !isOpenHandsVersionSupported(version)) {
+    return { supported: false, degraded: `OpenHands ${version} is outside the supported majors (${OPENHANDS_SUPPORTED_MAJORS.join(', ')}.x); observing disabled.`, records: [] };
+  }
+  const list = Array.isArray(events) ? events : [];
+  const records = list.map((e, i) => mapOpenHandsEvent(e, i)).filter((r): r is AgentObservationEvent => !!r);
+  return { supported: true, records };
+}
+
+/**
+ * The OpenHands tool-policy contract: tools live in the system prompt and cannot
+ * change mid-conversation. A policy change therefore starts a new conversation/
+ * fork — NEVER a silent mutation of the active run. This helper encodes that as
+ * the only legal outcome (asserted by tests); the observer never mutates a run.
+ */
+export function planToolPolicyChange(): { action: 'new-conversation'; mutatesActiveRun: false } {
+  return { action: 'new-conversation', mutatesActiveRun: false };
+}

--- a/FailSafe/extension/src/test/integrations/agent-observe/agent-observe.test.ts
+++ b/FailSafe/extension/src/test/integrations/agent-observe/agent-observe.test.ts
@@ -1,0 +1,117 @@
+import { strict as assert } from 'assert';
+import {
+  parseMcpPolicyConfig, flagMcpRisks, auditMcpConfig,
+} from '../../../integrations/agent-observe/mcp-policy-audit';
+import {
+  isOpenHandsVersionSupported, mapOpenHandsEvent, observeOpenHandsRun, planToolPolicyChange,
+} from '../../../integrations/agent-observe/openhands-observer';
+
+// ---- #106 Cline/Roo/Kilo MCP policy audit -------------------------------
+
+const SAFE_CONFIG = JSON.stringify({
+  mcpServers: { fs: { command: '/usr/local/bin/mcp-fs', args: ['--root', '.'], alwaysAllow: ['read_file'] } },
+});
+const RISKY_CONFIG = JSON.stringify({
+  mcpServers: {
+    sh: { command: 'bash', alwaysAllow: ['*'], env: { OPENAI_API_KEY: 'sk-TOPSECRET' } },
+    remote: { type: 'sse', url: 'https://hooks.evil.example.com/sse?token=SECRETTOKEN' },
+    fsx: { command: 'mcp-fs', autoApprove: ['read_file', 'write_file'] },
+  },
+});
+
+suite('mcp-policy-audit (#106)', () => {
+  test('parse redacts secrets: env VALUES dropped (keys kept), URL → host only, command → basename', () => {
+    const p = parseMcpPolicyConfig(JSON.parse(RISKY_CONFIG));
+    const sh = p.servers.find((s) => s.name === 'sh')!;
+    assert.deepEqual(sh.envKeys, ['OPENAI_API_KEY']);
+    assert.equal(sh.command, 'bash');
+    const remote = p.servers.find((s) => s.name === 'remote')!;
+    assert.equal(remote.transport, 'remote');
+    assert.equal(remote.urlHost, 'hooks.evil.example.com'); // no token, no path
+    // The secret token + api key must not survive anywhere in the parsed policy.
+    const s = JSON.stringify(p);
+    assert.ok(!s.includes('sk-TOPSECRET'), 'env value redacted');
+    assert.ok(!s.includes('SECRETTOKEN'), 'url token redacted');
+  });
+
+  test('parse reads both alwaysAllow and autoApprove field variants', () => {
+    const p = parseMcpPolicyConfig(JSON.parse(RISKY_CONFIG));
+    assert.deepEqual(p.servers.find((s) => s.name === 'sh')!.autoApprove, ['*']);
+    assert.deepEqual(p.servers.find((s) => s.name === 'fsx')!.autoApprove, ['read_file', 'write_file']);
+  });
+
+  test('safe config → no high-severity flags', () => {
+    const risks = auditMcpConfig('cline', SAFE_CONFIG);
+    assert.equal(risks.some((r) => r.severity === 'high'), false);
+  });
+
+  test('risky config → wildcard (high) + shell-capable (high) + remote (warn)', () => {
+    const risks = auditMcpConfig('cline', RISKY_CONFIG);
+    const byFlag = (f: string) => risks.find((r) => (r.provenance.flag as string) === f && (r.provenance.server as string) === 'sh' || (r.provenance.flag as string) === f && (r.provenance.server as string) === 'remote');
+    assert.ok(risks.some((r) => r.provenance.flag === 'wildcard-auto-approve' && r.severity === 'high'));
+    assert.ok(risks.some((r) => r.provenance.flag === 'shell-capable' && r.severity === 'high'));
+    assert.ok(risks.some((r) => r.provenance.flag === 'remote-mcp' && r.severity === 'warn'));
+    void byFlag;
+    // keyed-idempotent ids
+    assert.equal(new Set(risks.map((r) => r.id)).size, risks.length);
+  });
+
+  test('missing / empty / invalid config → no risks (works when agent absent)', () => {
+    assert.deepEqual(auditMcpConfig('roo', '{}'), []);
+    assert.deepEqual(auditMcpConfig('kilo', 'not json'), []);
+    assert.deepEqual(flagMcpRisks({ servers: [], globalAutoApprove: [] }, 'cline'), []);
+  });
+
+  test('global wildcard auto-approve flagged high', () => {
+    const risks = auditMcpConfig('kilo', JSON.stringify({ alwaysAllow: ['*'], mcpServers: {} }));
+    assert.ok(risks.some((r) => r.provenance.flag === 'wildcard-auto-approve' && r.provenance.scope === 'global' && r.severity === 'high'));
+  });
+});
+
+// ---- #105 OpenHands observer --------------------------------------------
+
+suite('openhands-observer (#105)', () => {
+  test('version support gate (pre-2.0 supported; garbage/undefined unsupported)', () => {
+    assert.equal(isOpenHandsVersionSupported('0.20.1'), true);
+    assert.equal(isOpenHandsVersionSupported('1.2.0'), true);
+    assert.equal(isOpenHandsVersionSupported('2.0.0'), false);
+    assert.equal(isOpenHandsVersionSupported('garbage'), false);
+    assert.equal(isOpenHandsVersionSupported(undefined), false);
+  });
+
+  test('mapOpenHandsEvent maps action/observation + risk hint; null on unrecognized', () => {
+    const run = mapOpenHandsEvent({ action: 'run', args: { command: 'rm -rf /' }, timestamp: '2026-06-04T00:00:00Z' });
+    assert.equal(run?.kind, 'action');
+    assert.equal(run?.verb, 'run');
+    assert.equal(run?.riskHint, 'high');
+    assert.equal(run?.tool, 'rm -rf /');
+    const read = mapOpenHandsEvent({ observation: 'read', args: { path: 'a.ts' } }, 3);
+    assert.equal(read?.kind, 'observation');
+    assert.equal(read?.riskHint, 'info');
+    assert.equal(read?.id, 'openhands:3');
+    assert.equal(mapOpenHandsEvent({ foo: 'bar' }), null);
+    assert.equal(mapOpenHandsEvent(null), null);
+  });
+
+  test('observeOpenHandsRun: unsupported version degrades gracefully (no records)', () => {
+    const r = observeOpenHandsRun([{ action: 'run' }], '2.5.0');
+    assert.equal(r.supported, false);
+    assert.match(r.degraded ?? '', /unsupported|outside the supported/i);
+    assert.equal(r.records.length, 0);
+  });
+
+  test('observeOpenHandsRun: supported version maps recognizable events only', () => {
+    const r = observeOpenHandsRun([{ action: 'edit', args: { path: 'x.ts' } }, { noise: true }, { observation: 'read' }], '0.30.0');
+    assert.equal(r.supported, true);
+    assert.equal(r.records.length, 2);
+    assert.equal(r.records[0].riskHint, 'warn');
+    // non-array tolerated
+    assert.deepEqual(observeOpenHandsRun(null, '0.30.0').records, []);
+  });
+
+  test('tool-policy change starts a new conversation — never mutates an active run', () => {
+    const plan = planToolPolicyChange();
+    assert.equal(plan.action, 'new-conversation');
+    assert.equal(plan.mutatesActiveRun, false);
+  });
+});


### PR DESCRIPTION
## Summary
Closes **#105** and **#106** (Group C — agent observe/detect/config-audit). Both are **read-only**: no process is spawned and no agent is mutated. The MCP-policy audit flags risky local agent configuration; the OpenHands observer maps an exported run into FailSafe transparency records.

## Cline / Roo / Kilo MCP-policy audit (#106)
`mcp-policy-audit.ts` (pure):
- **`parseMcpPolicyConfig`** — defensive parse of the shared `mcpServers` shape; reads **both** auto-approve field variants (`alwaysAllow` / `autoApprove`) so it isn't bet on one agent's exact schema; **redacts secrets** — env **values dropped** (keys kept), URL reduced to **host only** (no token/path), command reduced to **basename**.
- **`flagMcpRisks`** — wildcard auto-approval → **high**, shell/exec-capable server → **high**, remote MCP server → **warn**, broad auto-approve → **info**. Keyed-idempotent risk records (same shape as SARIF/Sentry → `RiskRegister` upsert).
- **`auditMcpConfig`** — parse + flag + dedup; invalid/empty JSON → **no risks** (so it works when the agents are absent).

| Acceptance | Where |
|---|---|
| Detection read-only + works when extensions absent | command scans candidate files; missing → no risks |
| Config parser redacts secrets and env values | `parseMcpPolicyConfig` (env values + URL tokens dropped) + redaction test |
| Risk flags: remote MCP, wildcard auto-approval, shell-capable | `flagMcpRisks` + risky-fixture test |
| Tests: missing / safe / risky fixtures | ✅ all present |

## OpenHands observer (#105)
`openhands-observer.ts` (pure):
- **`isOpenHandsVersionSupported`** (documented pre-2.0 majors; garbage/undefined → unsupported), **`mapOpenHandsEvent`** (defensive action/observation → normalized transparency record + risk hint; `null` on unrecognized), **`observeOpenHandsRun`** (unsupported version **degrades gracefully** — maps nothing, returns a notice), **`planToolPolicyChange`** (encodes the OpenHands contract: a tool-policy change starts a **new conversation/fork**, never mutates an active run).

| Acceptance | Where |
|---|---|
| Adapter documents supported version/API surface | `OPENHANDS_SUPPORTED_MAJORS` + docs index |
| Tool-policy changes fork instead of mutating active runs | `planToolPolicyChange` + test |
| Events map to FailSafe transparency schema | `mapOpenHandsEvent` → `AgentObservationEvent` |
| Tests: event mapping + unsupported-version degradation | ✅ all present |

## Commands / config
`FailSafe: Audit Agent MCP Policy (Cline/Roo/Kilo)` + `FailSafe: Import OpenHands Run (observe)`. Config: `failsafe.integrations.agentAudit.enabled` + `failsafe.integrations.openhands.{enabled, version}`. Off by default. Doc URLs per `INTEGRATION_DOCS_INDEX` (promote rows at the v5.5.0 squash).

Full `test:all` runs on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)