### PR TITLE
fix(bicameral): team-mode setup via integrated terminal + runStep timeout (#165)

### DIFF
--- a/FailSafe/extension/src/integrations/bicameral/install-handler.ts
+++ b/FailSafe/extension/src/integrations/bicameral/install-handler.ts
@@ -47,6 +47,16 @@ export interface InstallHandlerOptions {
   spawn?: typeof child_process.spawn;
   /** Test seam: override the post-setup verify probe. */
   verifyState?: (workspaceRoot: string, command: string) => Promise<BicameralInstallState>;
+  /** Interactive-terminal bridge (same shape as the AGT installer's runInTerminal).
+   *  REQUIRED for team-mode setup, which performs an interactive Google Drive
+   *  OAuth that cannot complete in the non-interactive spawn path (no TTY).
+   *  When absent in team mode, the handler errors with operator guidance rather
+   *  than hanging. FailSafe never reads/writes the OAuth token. */
+  runInTerminal?: (name: string, command: string) => void;
+  /** Per-step spawn timeout (ms). Defense-in-depth: kills a spawned child that
+   *  never responds (e.g. a process blocked on an interactive prompt) so the
+   *  install cannot hang indefinitely. Default 120000 (2 min). */
+  stepTimeoutMs?: number;
 }
 
 const VALID_MODES: ReadonlySet<InstallMode> = new Set(['solo', 'team']);
@@ -86,9 +96,33 @@ export async function runBicameralInstall(
   });
   if (!pipResult.ok) return finish(opts, mode, steps, pipResult.error || 'pip install failed');
 
+  const setupCommand = `${bicameral} setup --mode ${mode}`;
+
+  if (mode === 'team') {
+    // Team setup performs an interactive Google Drive OAuth (browser + console
+    // prompt). That CANNOT complete in the non-interactive spawn path (no TTY) —
+    // it would block forever (GH #165). Route it through the integrated terminal
+    // so the operator completes the OAuth in a real TTY, then re-probes via the
+    // card's Refresh. FailSafe never touches the OAuth token
+    // (~/.bicameral/google-drive-token.json). Verify is deferred because the
+    // config is not done until the operator finishes the OAuth.
+    const setupStep: InstallStep = { phase: 'setup', status: 'running', command: setupCommand };
+    steps.push(setupStep);
+    emit(opts, mode, steps, false);
+    if (!opts.runInTerminal) {
+      setupStep.status = 'error';
+      setupStep.error = `Team setup needs an interactive terminal for the Google Drive OAuth. Run \`${setupCommand}\` in a terminal, then click Refresh.`;
+      return finish(opts, mode, steps, setupStep.error);
+    }
+    opts.runInTerminal('Bicameral: team setup', setupCommand);
+    setupStep.status = 'success';
+    setupStep.stdoutTail = 'Complete the Google Drive OAuth in the opened terminal, then click Refresh to verify.';
+    return finish(opts, mode, steps);
+  }
+
   const setupResult = await runStep(opts, mode, steps, {
     phase: 'setup',
-    command: `${bicameral} setup --mode ${mode}`,
+    command: setupCommand,
     bin: bicameral,
     args: ['setup', '--mode', mode],
   });
@@ -147,6 +181,24 @@ async function runStep(
       resolve({ ok: false, error: step.error });
       return;
     }
+    // Defense-in-depth: a child that never closes (e.g. one blocked on an
+    // interactive prompt) must not hang the install forever. `settled` guards
+    // against a timeout/close race double-resolving or double-mutating the step.
+    let settled = false;
+    const timeoutMs = opts.stepTimeoutMs ?? 120_000;
+    const settle = (result: { ok: boolean; error?: string }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolve(result);
+    };
+    const timer = setTimeout(() => {
+      step.status = 'error';
+      step.error = `${req.bin} timed out after ${timeoutMs}ms (no response — an interactive prompt may be blocking).`;
+      try { child.kill(); } catch { /* best-effort */ }
+      emit(opts, mode, steps, false);
+      settle({ ok: false, error: step.error });
+    }, timeoutMs);
     let tail = '';
     child.stdout?.on('data', (chunk) => {
       tail = (tail + String(chunk)).slice(-STDOUT_TAIL_BYTES);
@@ -159,21 +211,23 @@ async function runStep(
       step.stdoutTail = sanitizeStdoutTail(tail);
     });
     child.on('error', (err) => {
+      if (settled) return;
       step.status = 'error';
       step.error = String(err);
       emit(opts, mode, steps, false);
-      resolve({ ok: false, error: step.error });
+      settle({ ok: false, error: step.error });
     });
     child.on('close', (code) => {
+      if (settled) return;
       if (code === 0) {
         step.status = 'success';
         emit(opts, mode, steps, false);
-        resolve({ ok: true });
+        settle({ ok: true });
       } else {
         step.status = 'error';
         step.error = `${req.bin} exited with code ${code}`;
         emit(opts, mode, steps, false);
-        resolve({ ok: false, error: step.error });
+        settle({ ok: false, error: step.error });
       }
     });
   });

--- a/FailSafe/extension/src/roadmap/routes/bicameralLifecycleRoutes.ts
+++ b/FailSafe/extension/src/roadmap/routes/bicameralLifecycleRoutes.ts
@@ -61,6 +61,11 @@ export function registerBicameralLifecycleRoutes(
       const result = await runBicameralInstall(
         {
           workspaceRoot: deps.workspaceRoot,
+          // GH #165: team-mode setup needs an interactive TTY for the Google
+          // Drive OAuth — route it through the integrated terminal bridge.
+          // Resolved at request time (the runner is wired lazily by bootstrap);
+          // undefined when no terminal is available → handler errors with guidance.
+          runInTerminal: deps.getRunInTerminal?.() ?? undefined,
           onProgress: (evt: InstallProgressEvent) => {
             deps.broadcast({
               type: evt.done ? "bicameral.install.complete" : "bicameral.install.progress",

--- a/FailSafe/extension/src/roadmap/routes/bicameralRouteShared.ts
+++ b/FailSafe/extension/src/roadmap/routes/bicameralRouteShared.ts
@@ -85,6 +85,15 @@ export interface BicameralRouteDeps {
   eventBus?: {
     emit(type: "bicameral.verdict", payload: BicameralVerdictEventPayload): void;
   };
+  /**
+   * GH #165: optional interactive-terminal bridge (shared with the AGT
+   * installer). When provided, team-mode `bicameral-mcp setup --mode team` is
+   * routed through the integrated terminal so its interactive Google Drive
+   * OAuth completes in a real TTY (the non-interactive spawn path hangs).
+   * Resolved at request time so it reflects the lazily-wired runner; absent →
+   * the install handler errors with operator guidance instead of hanging.
+   */
+  getRunInTerminal?: () => ((name: string, command: string) => void) | null;
 }
 
 /**

--- a/FailSafe/extension/src/roadmap/services/ConsoleRouteRegistrar.ts
+++ b/FailSafe/extension/src/roadmap/services/ConsoleRouteRegistrar.ts
@@ -291,6 +291,10 @@ export class ConsoleRouteRegistrar {
       },
       getAutoConnect: () => this.host.getBicameralAutoConnect(),
       setAutoConnect: (v) => this.host.setBicameralAutoConnect(v),
+      // GH #165: reuse the shared integrated-terminal runner (same one the AGT
+      // installer uses) so team-mode setup's interactive Google Drive OAuth runs
+      // in a real TTY. Lazy-resolved at request time (wired by bootstrap).
+      getRunInTerminal: () => this.host.getAgtRunInTerminal?.() ?? null,
       // B-BIC-1: pass ledger handle so ratify appends USER_OVERRIDE entry.
       ledgerManager: this.host.qorelogicManager.getLedgerManager() as any,
       // B-BIC-16: pass mediator handle so drift route forwards results

--- a/FailSafe/extension/src/test/integrations/bicameral/install-handler.test.ts
+++ b/FailSafe/extension/src/test/integrations/bicameral/install-handler.test.ts
@@ -65,16 +65,64 @@ suite('integrations/bicameral install-handler', () => {
     assert.equal(last.ok, true);
   });
 
-  test('team mode passes --mode team to setup', async () => {
+  // GH #165: team-mode setup runs an interactive Google Drive OAuth that cannot
+  // complete in a non-interactive spawn (no TTY) — it must route to the terminal.
+  test('team mode routes setup to the integrated terminal (NOT a non-interactive spawn)', async () => {
     const events: InstallProgressEvent[] = [];
-    const spawnFake = makeSpawnFake([{ exitCode: 0 }, { exitCode: 0 }]);
-    await runBicameralInstall({
+    const spawnFake = makeSpawnFake([{ exitCode: 0 }]); // only pip should spawn
+    const terminalCalls: Array<{ name: string; command: string }> = [];
+    const result = await runBicameralInstall({
       workspaceRoot: '/tmp/ws',
       onProgress: (e) => events.push(e),
       spawn: spawnFake.fn as never,
+      runInTerminal: (name, command) => terminalCalls.push({ name, command }),
       verifyState: fakeVerify('configured-not-running'),
     }, 'team');
-    assert.deepEqual(spawnFake.calls[1].args, ['setup', '--mode', 'team']);
+    assert.equal(spawnFake.calls.length, 1, 'team setup must NOT spawn (it would hang on OAuth)');
+    assert.equal(spawnFake.calls[0].bin, 'pip');
+    assert.equal(terminalCalls.length, 1, 'team setup routed to the integrated terminal');
+    assert.match(terminalCalls[0].command, /setup --mode team/);
+    assert.equal(result.done, true);
+    assert.equal(result.ok, true);
+    const setupStep = result.steps.find((s) => s.phase === 'setup');
+    assert.equal(setupStep?.status, 'success');
+    assert.match(setupStep?.stdoutTail || '', /OAuth/i);
+  });
+
+  test('team mode without a terminal bridge errors with guidance (does not hang/spawn setup)', async () => {
+    const events: InstallProgressEvent[] = [];
+    const spawnFake = makeSpawnFake([{ exitCode: 0 }]);
+    const result = await runBicameralInstall({
+      workspaceRoot: '/tmp/ws',
+      onProgress: (e) => events.push(e),
+      spawn: spawnFake.fn as never,
+      // no runInTerminal wired
+    }, 'team');
+    assert.equal(spawnFake.calls.length, 1, 'only pip spawns; setup is never spawned');
+    assert.equal(result.ok, false);
+    assert.match(result.error || '', /interactive terminal/i);
+    assert.equal(result.steps.find((s) => s.phase === 'setup')?.status, 'error');
+  });
+
+  test('runStep timeout: a spawned child that never closes is killed and errors', async () => {
+    const events: InstallProgressEvent[] = [];
+    let killed = false;
+    const spawnFn = (() => {
+      const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter; kill: () => void };
+      (child as { stdout: EventEmitter }).stdout = new EventEmitter();
+      (child as { stderr: EventEmitter }).stderr = new EventEmitter();
+      child.kill = () => { killed = true; };
+      return child; // never emits 'close'/'error' → the timeout must fire
+    }) as never;
+    const result = await runBicameralInstall({
+      workspaceRoot: '/tmp/ws',
+      onProgress: (e) => events.push(e),
+      spawn: spawnFn,
+      stepTimeoutMs: 30, // tiny + child never closes → deterministic, not flaky
+    }, 'solo');
+    assert.equal(result.ok, false);
+    assert.match(result.error || '', /timed out/i);
+    assert.equal(killed, true, 'the hung child must be killed');
   });
 
   test('pip install failure halts before setup', async () => {


### PR DESCRIPTION
## Summary

Fixes **#165** — bicameral install succeeds for the pip + setup steps but the **`setup` component fails when "team" mode is selected**. Root cause: team-mode `bicameral-mcp setup --mode team` runs an **interactive Google Drive OAuth** (browser + console prompt) that cannot complete in the non-interactive `spawn` path (no TTY) — it blocked indefinitely.

## Fix

- **Team mode** now routes `bicameral-mcp setup --mode team` through the **existing `runInTerminal` bridge** (the same one the AGT installer uses) so the operator completes the OAuth in a real TTY, then re-probes via the card's **Refresh**. `pip install` still runs non-interactively first; only the interactive `setup` step is handed to the terminal.
- **Solo mode** is unchanged — stays on the non-interactive `spawn` path.
- **Defense-in-depth:** added a per-step spawn **timeout** to `runStep` (default 120s, `stepTimeoutMs`-overridable) with a `settled` guard, so any child blocked on an interactive prompt is killed instead of hanging the install forever.
- FailSafe **never** reads/writes the OAuth token (`~/.bicameral/google-drive-token.json`).

## Wiring (verified file:line)

`install-handler` (`runInTerminal` / `stepTimeoutMs` opts) → `bicameralLifecycleRoutes` passes `deps.getRunInTerminal?.()` → `bicameralRouteShared.BicameralRouteDeps.getRunInTerminal` → `ConsoleRouteRegistrar` wires `host.getAgtRunInTerminal()`.

## Tests

`install-handler.test.ts`:
- team → routes setup to the integrated terminal (pip-only spawn; terminal receives `setup --mode team`; setup step success; OAuth-guidance tail)
- team without a terminal bridge → errors with operator guidance (never spawns setup)
- solo → spawn path unchanged
- `runStep` timeout → a never-closing child is killed and errors

Runtime-verified all four paths; `tsc` 0 errors, eslint 0 errors.

## Notes

- Part of **v5.5.2** (PATCH — completing v5.5.0's incomplete integration delivery).
- This PR is code + tests only (no META_LEDGER entry — deferred until #164 settles the chain).
- Will be BLOCKED by the `code_scanning`/`code_quality` ruleset on `main` — that gate is an **intentional human merge gate**; merge requires explicit operator authorization.

Closes #165.

🤖 Generated with [Claude Code](https://claude.com/claude-code)