### PR TITLE
fix(test): recover v5.5.2 — pin Integrations sub-view in Bicameral/tab Playwright specs (#167)

### DIFF
--- a/FailSafe/extension/src/test/ui/bicameral-advanced-tools.spec.ts
+++ b/FailSafe/extension/src/test/ui/bicameral-advanced-tools.spec.ts
@@ -64,6 +64,8 @@ test.describe('FX589 — Bicameral Advanced-tools section (B-INT-1)', () => {
     });
     await page.goto(`${controller.url}/command-center.html`);
     await page.locator('.tab-btn[data-target="integrations"]').click();
+    // Catalog is now the default Integrations sub-view (#167) — select Bicameral.
+    await page.locator('.cc-pill[data-key="bicameral"]').click();
 
     // Connect to reach the running state, where the Advanced-tools section mounts.
     const connectBtn = page.locator('[data-action="bicameral-connect"]');

--- a/FailSafe/extension/src/test/ui/integrations-bicameral-overflow.spec.ts
+++ b/FailSafe/extension/src/test/ui/integrations-bicameral-overflow.spec.ts
@@ -55,6 +55,8 @@ const FEATURES: BicameralFeatureBrief[] = [
 async function gotoRunningFeed(page: import('@playwright/test').Page, url: string) {
   await page.goto(`${url}/command-center.html`);
   await page.locator('.tab-btn[data-target="integrations"]').click();
+  // Catalog is now the default Integrations sub-view (#167) — select Bicameral.
+  await page.locator('.cc-pill[data-key="bicameral"]').click();
   await page.locator('[data-action="bicameral-connect"]').click();
   await expect(page.locator('.cc-bicameral-decision[data-decision-id="d-long"]')).toBeVisible({ timeout: 5000 });
 }

--- a/FailSafe/extension/src/test/ui/integrations-bicameral.spec.ts
+++ b/FailSafe/extension/src/test/ui/integrations-bicameral.spec.ts
@@ -98,6 +98,8 @@ test.describe('FX487/488/489/490 — Bicameral Integrations tab (Phase 5)', () =
     controller = await serveConsoleServerUI({ bicameralClient: client, bicameralConfigured: true });
     await page.goto(`${controller.url}/command-center.html`);
     await page.locator('.tab-btn[data-target="integrations"]').click();
+    // Catalog is now the default Integrations sub-view (#167) — select Bicameral.
+    await page.locator('.cc-pill[data-key="bicameral"]').click();
 
     // The integrations.js renderer runs the status probe on first render;
     // wait for the configured-not-running state to surface the Connect button.
@@ -112,6 +114,8 @@ test.describe('FX487/488/489/490 — Bicameral Integrations tab (Phase 5)', () =
     controller = await serveConsoleServerUI({ bicameralClient: client, bicameralConfigured: true });
     await page.goto(`${controller.url}/command-center.html`);
     await page.locator('.tab-btn[data-target="integrations"]').click();
+    // Catalog is now the default Integrations sub-view (#167) — select Bicameral.
+    await page.locator('.cc-pill[data-key="bicameral"]').click();
 
     const connectBtn = page.locator('[data-action="bicameral-connect"]');
     await expect(connectBtn).toBeVisible({ timeout: 5000 });
@@ -135,6 +139,8 @@ test.describe('FX487/488/489/490 — Bicameral Integrations tab (Phase 5)', () =
     controller = await serveConsoleServerUI({ bicameralClient: client, bicameralConfigured: true });
     await page.goto(`${controller.url}/command-center.html`);
     await page.locator('.tab-btn[data-target="integrations"]').click();
+    // Catalog is now the default Integrations sub-view (#167) — select Bicameral.
+    await page.locator('.cc-pill[data-key="bicameral"]').click();
     await page.locator('[data-action="bicameral-connect"]').click();
 
     // Wait for the feed to render, then click the Ratify button on d-001.
@@ -154,6 +160,8 @@ test.describe('FX487/488/489/490 — Bicameral Integrations tab (Phase 5)', () =
     controller = await serveConsoleServerUI({ bicameralCommand: '__failsafe_test_no_such_command__' });
     await page.goto(`${controller.url}/command-center.html`);
     await page.locator('.tab-btn[data-target="integrations"]').click();
+    // Catalog is now the default Integrations sub-view (#167) — select Bicameral.
+    await page.locator('.cc-pill[data-key="bicameral"]').click();
 
     // Both install buttons render in not-installed state per bicameral-card.js.
     const installSolo = page.locator('[data-action="bicameral-install"][data-mode="solo"]');

--- a/FailSafe/extension/src/test/ui/integrations-tab.spec.ts
+++ b/FailSafe/extension/src/test/ui/integrations-tab.spec.ts
@@ -73,27 +73,32 @@ test("B-INT-5 Integrations sub-tabs — pill switch swaps the visible integratio
   await page.goto(`${controller.url}/command-center.html`);
   await page.locator('.tab-btn[data-target="integrations"]').click();
 
-  // Four integration pills render in the sub-view bar.
+  // Five integration pills render in the sub-view bar (Catalog added first, #167).
   const pills = page.locator('#integrations .cc-subview-bar .cc-pill');
-  await expect(pills).toHaveCount(4, { timeout: 10000 });
-  await expect(pills.nth(0)).toHaveText('Bicameral');
-  await expect(pills.nth(1)).toHaveText('Open Design');
-  await expect(pills.nth(3)).toHaveText('Agent Governance');
-  await expect(pills.nth(2)).toHaveText('MCP Catalog');
+  await expect(pills).toHaveCount(5, { timeout: 10000 });
+  await expect(pills.nth(0)).toHaveText('Catalog');
+  await expect(pills.nth(1)).toHaveText('Bicameral');
+  await expect(pills.nth(2)).toHaveText('Open Design');
+  await expect(pills.nth(3)).toHaveText('MCP Catalog');
+  await expect(pills.nth(4)).toHaveText('Agent Governance');
 
-  // Bicameral is the default active sub-view.
-  await expect(page.locator('#integrations .cc-bicameral-card')).toBeVisible({ timeout: 10000 });
-  await expect(page.locator('#integrations .cc-open-design-card')).toHaveCount(0);
+  // Catalog is the default active sub-view (#167).
+  await expect(page.locator('#integrations .cc-intcat-card').first()).toBeVisible({ timeout: 10000 });
+  await expect(page.locator('#integrations .cc-bicameral-card')).toHaveCount(0);
 
-  // Selecting the Open Design pill swaps the visible sub-view.
+  // Selecting the Bicameral pill swaps the visible sub-view.
   await pills.nth(1).click();
+  await expect(page.locator('#integrations .cc-bicameral-card')).toBeVisible({ timeout: 10000 });
+
+  // Selecting the Open Design pill swaps it again.
+  await pills.nth(2).click();
   const odCard = page.locator('#integrations .cc-open-design-card');
   await expect(odCard).toBeVisible({ timeout: 10000 });
   await expect(odCard).toContainText('Open Design MCP');
   await expect(page.locator('#integrations .cc-bicameral-card')).toHaveCount(0);
 
   // Selecting Bicameral again restores it.
-  await pills.nth(0).click();
+  await pills.nth(1).click();
   await expect(page.locator('#integrations .cc-bicameral-card')).toBeVisible({ timeout: 10000 });
   await expect(page.locator('#integrations .cc-open-design-card')).toHaveCount(0);
 });


### PR DESCRIPTION
## Recovers the dead v5.5.2 tag

v5.5.2's Build & Test failed (publish skipped — **nothing published**) because #167 made the new **Catalog** sub-view the default pill of the Integrations tab, and 4 existing Playwright specs assumed Bicameral was the default — they timed out reaching `[data-action="bicameral-connect"]`.

### Fix (test-only — product code unchanged)
- `integrations-bicameral.spec.ts`, `bicameral-advanced-tools.spec.ts`, `integrations-bicameral-overflow.spec.ts` — select `.cc-pill[data-key="bicameral"]` after opening the Integrations tab.
- `integrations-tab.spec.ts` — updated for the new pill order (Catalog first, count 5) + Catalog-as-default assertion + shifted indices.

### Verification
Full Playwright suite re-run locally — the 4 deterministic failures are gone (one electron flake observed under full-suite load passes cleanly in isolation, 3.8s).

### Release mechanics
Test-only recovery; **META_LEDGER #420 remains the v5.5.2 DELIVER seal** (no new seal needed). After merge, the `v5.5.2` tag is re-pointed to the fixed `main` commit and re-pushed to re-trigger the pipeline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)